### PR TITLE
[Merged by Bors] - Stabilize hdfs cluster install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 - Reconciliation errors are now reported as Kubernetes events ([#130]).
 - Use cli argument `watch-namespace` / env var `WATCH_NAMESPACE` to specify
   a single namespace to watch ([#134]).
+- Config builder for `hdfs-site.xml` and `core-site.xml` ([#150]).
+- Discovery configmap that exposes the namenode services for clients to connect ([#150]). 
 
 ### Changed
 
@@ -18,6 +20,7 @@ All notable changes to this project will be documented in this file.
 [#122]: https://github.com/stackabletech/hdfs-operator/pull/122
 [#130]: https://github.com/stackabletech/hdfs-operator/pull/130
 [#134]: https://github.com/stackabletech/hdfs-operator/pull/134
+[#150]: https://github.com/stackabletech/hdfs-operator/pull/150
 
 ## [0.3.0] - 2022-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ All notable changes to this project will be documented in this file.
 - Use cli argument `watch-namespace` / env var `WATCH_NAMESPACE` to specify
   a single namespace to watch ([#134]).
 - Config builder for `hdfs-site.xml` and `core-site.xml` ([#150]).
-- Discovery configmap that exposes the namenode services for clients to connect ([#150]). 
+- Discovery configmap that exposes the namenode services for clients to connect ([#150]).
+- Documented service discovery for namenodes ([#150]). 
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,6 @@ All notable changes to this project will be documented in this file.
 
 ## [0.2.0] - 2021-11-12
 
-
 - `operator-rs` `0.3.0` → `0.4.0` ([#20]).
 - Adapted pod image and container command to docker image ([#20]).
 - Adapted documentation to represent new workflow with docker images ([#20]). 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
   a single namespace to watch ([#134]).
 - Config builder for `hdfs-site.xml` and `core-site.xml` ([#150]).
 - Discovery configmap that exposes the namenode services for clients to connect ([#150]).
-- Documented service discovery for namenodes ([#150]). 
+- Documented service discovery for namenodes ([#150]).
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1489,7 +1489,6 @@ name = "stackable-hdfs-operator"
 version = "0.4.0-nightly"
 dependencies = [
  "futures",
- "lazy_static",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/deploy/config-spec/properties.yaml
+++ b/deploy/config-spec/properties.yaml
@@ -73,14 +73,11 @@ properties:
       datatype:
         type: "string"
         unit: *unitUri
-      defaultValues:
-        - fromVersion: "0.0.0"
-          value: "0.0.0.0:9000"
       roles:
         - name: "namenode"
-          required: true
+          required: false
         - name: "datanode"
-          required: true
+          required: false
       asOfVersion: "0.0.0"
       description: "The name of the default file system. A URI whose scheme and authority determine the FileSystem implementation. The uri's scheme determines the config property (fs.SCHEME.impl) naming the FileSystem implementation class. The uri's authority is used to determine the host, port, etc. for a filesystem."
 
@@ -92,9 +89,6 @@ properties:
             file: "hdfs-site.xml"
       datatype:
         type: "string"
-      defaultValues:
-        - fromVersion: "3.0.0"
-          value: "0.0.0.0:9870"
       roles:
         - name: "namenode"
           required: false
@@ -109,12 +103,9 @@ properties:
             file: "hdfs-site.xml"
       datatype:
         type: "string"
-      defaultValues:
-        - fromVersion: "3.0.0"
-          value: "0.0.0.0:9867"
       roles:
         - name: "datanode"
-          required: true
+          required: false
       asOfVersion: "0.0.0"
       description: "The datanode ipc server address and port."
 
@@ -126,12 +117,9 @@ properties:
             file: "hdfs-site.xml"
       datatype:
         type: "string"
-      defaultValues:
-        - fromVersion: "3.0.0"
-          value: "0.0.0.0:9866"
       roles:
         - name: "datanode"
-          required: true
+          required: false
       asOfVersion: "0.0.0"
       description: "The datanode server address and port for data transfer."
 
@@ -143,12 +131,9 @@ properties:
             file: "hdfs-site.xml"
       datatype:
         type: "string"
-      defaultValues:
-        - fromVersion: "3.0.0"
-          value: "0.0.0.0:9864"
       roles:
         - name: "datanode"
-          required: true
+          required: false
       asOfVersion: "0.0.0"
       description: "The datanode http server address and port."
 
@@ -160,11 +145,8 @@ properties:
             file: "hdfs-site.xml"
       datatype:
         type: "string"
-      defaultValues:
-        - fromVersion: "3.0.0"
-          value: "0.0.0.0:8480"
       roles:
-        - name: "journanode"
+        - name: "journalnode"
           required: false
       asOfVersion: "0.0.0"
       description: "The address and port the JournalNode HTTP server listens on. If the port is 0 then the server will start on a free port."
@@ -177,11 +159,8 @@ properties:
             file: "hdfs-site.xml"
       datatype:
         type: "string"
-      defaultValues:
-        - fromVersion: "3.0.0"
-          value: "0.0.0.0:8481"
       roles:
-        - name: "journanode"
+        - name: "journalnode"
           required: false
       asOfVersion: "0.0.0"
       description: "The address and port the JournalNode HTTPS server listens on. If the port is 0 then the server will start on a free port."

--- a/deploy/helm/hdfs-operator/configs/properties.yaml
+++ b/deploy/helm/hdfs-operator/configs/properties.yaml
@@ -73,14 +73,11 @@ properties:
       datatype:
         type: "string"
         unit: *unitUri
-      defaultValues:
-        - fromVersion: "0.0.0"
-          value: "0.0.0.0:9000"
       roles:
         - name: "namenode"
-          required: true
+          required: false
         - name: "datanode"
-          required: true
+          required: false
       asOfVersion: "0.0.0"
       description: "The name of the default file system. A URI whose scheme and authority determine the FileSystem implementation. The uri's scheme determines the config property (fs.SCHEME.impl) naming the FileSystem implementation class. The uri's authority is used to determine the host, port, etc. for a filesystem."
 
@@ -92,9 +89,6 @@ properties:
             file: "hdfs-site.xml"
       datatype:
         type: "string"
-      defaultValues:
-        - fromVersion: "3.0.0"
-          value: "0.0.0.0:9870"
       roles:
         - name: "namenode"
           required: false
@@ -109,12 +103,9 @@ properties:
             file: "hdfs-site.xml"
       datatype:
         type: "string"
-      defaultValues:
-        - fromVersion: "3.0.0"
-          value: "0.0.0.0:9867"
       roles:
         - name: "datanode"
-          required: true
+          required: false
       asOfVersion: "0.0.0"
       description: "The datanode ipc server address and port."
 
@@ -126,12 +117,9 @@ properties:
             file: "hdfs-site.xml"
       datatype:
         type: "string"
-      defaultValues:
-        - fromVersion: "3.0.0"
-          value: "0.0.0.0:9866"
       roles:
         - name: "datanode"
-          required: true
+          required: false
       asOfVersion: "0.0.0"
       description: "The datanode server address and port for data transfer."
 
@@ -143,12 +131,9 @@ properties:
             file: "hdfs-site.xml"
       datatype:
         type: "string"
-      defaultValues:
-        - fromVersion: "3.0.0"
-          value: "0.0.0.0:9864"
       roles:
         - name: "datanode"
-          required: true
+          required: false
       asOfVersion: "0.0.0"
       description: "The datanode http server address and port."
 
@@ -160,11 +145,8 @@ properties:
             file: "hdfs-site.xml"
       datatype:
         type: "string"
-      defaultValues:
-        - fromVersion: "3.0.0"
-          value: "0.0.0.0:8480"
       roles:
-        - name: "journanode"
+        - name: "journalnode"
           required: false
       asOfVersion: "0.0.0"
       description: "The address and port the JournalNode HTTP server listens on. If the port is 0 then the server will start on a free port."
@@ -177,11 +159,8 @@ properties:
             file: "hdfs-site.xml"
       datatype:
         type: "string"
-      defaultValues:
-        - fromVersion: "3.0.0"
-          value: "0.0.0.0:8481"
       roles:
-        - name: "journanode"
+        - name: "journalnode"
           required: false
       asOfVersion: "0.0.0"
       description: "The address and port the JournalNode HTTPS server listens on. If the port is 0 then the server will start on a free port."

--- a/deploy/manifests/configmap.yaml
+++ b/deploy/manifests/configmap.yaml
@@ -78,14 +78,11 @@ data:
           datatype:
             type: "string"
             unit: *unitUri
-          defaultValues:
-            - fromVersion: "0.0.0"
-              value: "0.0.0.0:9000"
           roles:
             - name: "namenode"
-              required: true
+              required: false
             - name: "datanode"
-              required: true
+              required: false
           asOfVersion: "0.0.0"
           description: "The name of the default file system. A URI whose scheme and authority determine the FileSystem implementation. The uri's scheme determines the config property (fs.SCHEME.impl) naming the FileSystem implementation class. The uri's authority is used to determine the host, port, etc. for a filesystem."
   
@@ -97,9 +94,6 @@ data:
                 file: "hdfs-site.xml"
           datatype:
             type: "string"
-          defaultValues:
-            - fromVersion: "3.0.0"
-              value: "0.0.0.0:9870"
           roles:
             - name: "namenode"
               required: false
@@ -114,12 +108,9 @@ data:
                 file: "hdfs-site.xml"
           datatype:
             type: "string"
-          defaultValues:
-            - fromVersion: "3.0.0"
-              value: "0.0.0.0:9867"
           roles:
             - name: "datanode"
-              required: true
+              required: false
           asOfVersion: "0.0.0"
           description: "The datanode ipc server address and port."
   
@@ -131,12 +122,9 @@ data:
                 file: "hdfs-site.xml"
           datatype:
             type: "string"
-          defaultValues:
-            - fromVersion: "3.0.0"
-              value: "0.0.0.0:9866"
           roles:
             - name: "datanode"
-              required: true
+              required: false
           asOfVersion: "0.0.0"
           description: "The datanode server address and port for data transfer."
   
@@ -148,12 +136,9 @@ data:
                 file: "hdfs-site.xml"
           datatype:
             type: "string"
-          defaultValues:
-            - fromVersion: "3.0.0"
-              value: "0.0.0.0:9864"
           roles:
             - name: "datanode"
-              required: true
+              required: false
           asOfVersion: "0.0.0"
           description: "The datanode http server address and port."
   
@@ -165,11 +150,8 @@ data:
                 file: "hdfs-site.xml"
           datatype:
             type: "string"
-          defaultValues:
-            - fromVersion: "3.0.0"
-              value: "0.0.0.0:8480"
           roles:
-            - name: "journanode"
+            - name: "journalnode"
               required: false
           asOfVersion: "0.0.0"
           description: "The address and port the JournalNode HTTP server listens on. If the port is 0 then the server will start on a free port."
@@ -182,11 +164,8 @@ data:
                 file: "hdfs-site.xml"
           datatype:
             type: "string"
-          defaultValues:
-            - fromVersion: "3.0.0"
-              value: "0.0.0.0:8481"
           roles:
-            - name: "journanode"
+            - name: "journalnode"
               required: false
           asOfVersion: "0.0.0"
           description: "The address and port the JournalNode HTTPS server listens on. If the port is 0 then the server will start on a free port."

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -2,3 +2,5 @@
 * xref:configuration.adoc[]
 * xref:usage.adoc[]
 * xref:implementation.adoc[]
+* Concepts
+** xref:discovery.adoc[]

--- a/docs/modules/ROOT/pages/discovery.adoc
+++ b/docs/modules/ROOT/pages/discovery.adoc
@@ -1,0 +1,39 @@
+:clusterName: \{clusterName\}
+:namespace: \{namespace\}
+
+= Discovery
+
+The Stackable Operator for Apache HDFS publishes a discovery https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmap-v1-core[`ConfigMap`], which exposes a client configuration bundle that allows access to the Apache HDFS cluster.
+
+== Example
+
+Given the following HDFS cluster:
+
+[source,yaml,subs="normal,callouts"]
+----
+apiVersion: hdfs.stackable.tech/v1alpha1
+kind: HdfsCluster
+metadata:
+  name: {clusterName} # <1>
+  namespace: {namespace} # <2>
+spec:
+  namenode:
+    roleGroups:
+      default: # <3>
+  [...]
+----
+<1> The name of the HDFS cluster, which is also the name of the created discovery `ConfigMap`.
+<2> The namespace of the discovery `ConfigMap`.
+<3> A role group name of the `namenode` role.
+
+The resulting discovery `ConfigMap` is located at `{namespace}/{clusterName}`.
+
+== Contents
+
+The `ConfigMap` data values are formatted as Hadoop XML files which allows simple mounting of that ConfigMap into pods that require access to HDFS.
+
+`core-site.xml`::
+Contains the `fs.DefaultFS` which defaults to `hdfs://{clusterName}/`.
+
+`hdfs-site.xml`::
+Contains the `dfs.namenode.*` properties for `rpc` and `http` addresses for the `namenodes` as well as the `dfs.nameservices` property which defaults to `hdfs://{clusterName}/`.

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -91,7 +91,7 @@ xref:home::monitoring.adoc[] for more details.
 
 The cluster definition also supports overriding configuration properties and environment variables, either per role or per role group, where the more specific override (role group) has precedence over the less specific one (role).
 
-IMPORTANT: Overriding certain properties can lead to faulty clusters. In general this means, do not change ports, hostnames or properties related to high-availability or security.
+IMPORTANT: Overriding certain properties can lead to faulty clusters. In general this means, do not change ports, hostnames or properties related to data dirs, high-availability or security.
 
 === Configuration Properties
 

--- a/examples/simple-hdfs-cluster.yaml
+++ b/examples/simple-hdfs-cluster.yaml
@@ -29,7 +29,7 @@ metadata:
 spec:
   version: 3.2.2
   zookeeperConfigMapName: simple-hdfs-znode
-  dfsReplication: 3
+  dfsReplication: 1
   log4j: |-
     # Define some default values that can be overridden by system properties
     hadoop.root.logger=INFO,console

--- a/examples/simple-hdfs-cluster.yaml
+++ b/examples/simple-hdfs-cluster.yaml
@@ -57,11 +57,11 @@ spec:
         selector:
           matchLabels:
             kubernetes.io/os: linux
-        replicas: 3
+        replicas: 1
   journalNodes:
     roleGroups:
       default:
         selector:
           matchLabels:
             kubernetes.io/os: linux
-        replicas: 3
+        replicas: 1

--- a/rust/crd/src/constants.rs
+++ b/rust/crd/src/constants.rs
@@ -34,3 +34,22 @@ pub const DEFAULT_JOURNAL_NODE_METRICS_PORT: i32 = 8081;
 pub const DEFAULT_JOURNAL_NODE_HTTP_PORT: i32 = 8480;
 pub const DEFAULT_JOURNAL_NODE_HTTPS_PORT: i32 = 8481;
 pub const DEFAULT_JOURNAL_NODE_RPC_PORT: i32 = 8485;
+
+// hdfs-site.xml
+// namenode
+pub const DFS_NAMENODE_NAME_DIR: &str = "dfs.namenode.name.dir";
+pub const DFS_NAMENODE_SHARED_EDITS_DIR: &str = "dfs.namenode.shared.edits.dir";
+pub const DFS_NAMENODE_RPC_ADDRESS: &str = "dfs.namenode.rpc-address";
+pub const DFS_NAMENODE_HTTP_ADDRESS: &str = "dfs.namenode.http-address";
+// datanode
+pub const DFS_DATANODE_DATA_DIR: &str = "dfs.datanode.data.dir";
+// journalnode
+pub const DFS_JOURNALNODE_EDITS_DIR: &str = "dfs.journalnode.edits.dir";
+pub const DFS_JOURNALNODE_RPC_ADDRESS: &str = "dfs.journalnode.rpc-address";
+// misc
+pub const DFS_REPLICATION: &str = "dfs.replication";
+pub const DFS_NAME_SERVICES: &str = "dfs.nameservices";
+
+// core-site.xml
+pub const FS_DEFAULT_FS: &str = "fs.defaultFS";
+pub const HA_ZOOKEEPER_QUORUM: &str = "ha.zookeeper.quorum";

--- a/rust/crd/src/constants.rs
+++ b/rust/crd/src/constants.rs
@@ -34,22 +34,3 @@ pub const DEFAULT_JOURNAL_NODE_METRICS_PORT: i32 = 8081;
 pub const DEFAULT_JOURNAL_NODE_HTTP_PORT: i32 = 8480;
 pub const DEFAULT_JOURNAL_NODE_HTTPS_PORT: i32 = 8481;
 pub const DEFAULT_JOURNAL_NODE_RPC_PORT: i32 = 8485;
-
-// hdfs-site.xml
-// namenode
-pub const DFS_NAMENODE_NAME_DIR: &str = "dfs.namenode.name.dir";
-pub const DFS_NAMENODE_SHARED_EDITS_DIR: &str = "dfs.namenode.shared.edits.dir";
-pub const DFS_NAMENODE_RPC_ADDRESS: &str = "dfs.namenode.rpc-address";
-pub const DFS_NAMENODE_HTTP_ADDRESS: &str = "dfs.namenode.http-address";
-// datanode
-pub const DFS_DATANODE_DATA_DIR: &str = "dfs.datanode.data.dir";
-// journalnode
-pub const DFS_JOURNALNODE_EDITS_DIR: &str = "dfs.journalnode.edits.dir";
-pub const DFS_JOURNALNODE_RPC_ADDRESS: &str = "dfs.journalnode.rpc-address";
-// misc
-pub const DFS_REPLICATION: &str = "dfs.replication";
-pub const DFS_NAME_SERVICES: &str = "dfs.nameservices";
-
-// core-site.xml
-pub const FS_DEFAULT_FS: &str = "fs.defaultFS";
-pub const HA_ZOOKEEPER_QUORUM: &str = "ha.zookeeper.quorum";

--- a/rust/crd/src/constants.rs
+++ b/rust/crd/src/constants.rs
@@ -9,6 +9,7 @@ pub const LABEL_ENABLE: &str = "hdfs.stackable.tech/pod-service";
 pub const LABEL_STS_POD_NAME: &str = "statefulset.kubernetes.io/pod-name";
 
 pub const CONFIG_DIR_NAME: &str = "/stackable/hadoop/etc/hadoop";
+pub const HADOOP_HOME: &str = "/stackable/hadoop";
 
 pub const HDFS_SITE_XML: &str = "hdfs-site.xml";
 pub const CORE_SITE_XML: &str = "core-site.xml";

--- a/rust/crd/src/constants.rs
+++ b/rust/crd/src/constants.rs
@@ -34,3 +34,19 @@ pub const DEFAULT_JOURNAL_NODE_METRICS_PORT: i32 = 8081;
 pub const DEFAULT_JOURNAL_NODE_HTTP_PORT: i32 = 8480;
 pub const DEFAULT_JOURNAL_NODE_HTTPS_PORT: i32 = 8481;
 pub const DEFAULT_JOURNAL_NODE_RPC_PORT: i32 = 8485;
+
+// hdfs-site.xml
+pub const DFS_NAMENODE_NAME_DIR: &str = "dfs.namenode.name.dir";
+pub const DFS_NAMENODE_SHARED_EDITS_DIR: &str = "dfs.namenode.shared.edits.dir";
+pub const DFS_NAMENODE_RPC_ADDRESS: &str = "dfs.namenode.rpc-address";
+pub const DFS_NAMENODE_HTTP_ADDRESS: &str = "dfs.namenode.http-address";
+pub const DFS_DATANODE_DATA_DIR: &str = "dfs.datanode.data.dir";
+pub const DFS_JOURNALNODE_EDITS_DIR: &str = "dfs.journalnode.edits.dir";
+pub const DFS_JOURNALNODE_RPC_ADDRESS: &str = "dfs.journalnode.rpc-address";
+pub const DFS_REPLICATION: &str = "dfs.replication";
+pub const DFS_NAME_SERVICES: &str = "dfs.nameservices";
+pub const DFS_HA_NAMENODES: &str = "dfs.ha.namenodes";
+
+// core-site.xml
+pub const FS_DEFAULT_FS: &str = "fs.defaultFS";
+pub const HA_ZOOKEEPER_QUORUM: &str = "ha.zookeeper.quorum";

--- a/rust/crd/src/error.rs
+++ b/rust/crd/src/error.rs
@@ -49,6 +49,12 @@ pub enum Error {
         name: String,
     },
 
+    #[error("Cannot create discovery config map {name}. Caused by: {source}")]
+    ApplyDiscoveryConfigMap {
+        source: stackable_operator::error::Error,
+        name: String,
+    },
+
     #[error("No metadata for [{obj_ref}]. Caused by: {source}")]
     ObjectMissingMetadataForOwnerRef {
         source: stackable_operator::error::Error,
@@ -77,6 +83,12 @@ pub enum Error {
         source: stackable_operator::error::Error,
         role: String,
         role_group: String,
+    },
+
+    #[error("Cannot build config discovery config map {name}. Caused by: {source}")]
+    BuildDiscoveryConfigMap {
+        source: stackable_operator::error::Error,
+        name: String,
     },
 
     #[error("Pod has no name")]

--- a/rust/crd/src/error.rs
+++ b/rust/crd/src/error.rs
@@ -8,19 +8,15 @@ use strum::EnumDiscriminants;
 #[derive(Debug, thiserror::Error, EnumDiscriminants)]
 #[strum_discriminants(derive(strum::IntoStaticStr))]
 pub enum Error {
-    #[error("object has no version")]
+    #[error("Object has no version")]
     ObjectHasNoVersion { obj_ref: ObjectRef<HdfsCluster> },
-    #[error("no namenode role defined")]
-    NoNameNodeRole,
-    #[error("no datanode role defined")]
-    NoDataNodeRole,
-    #[error("no journalnode role defined")]
-    NoJournalNodeRole,
-    #[error("invalid role configuration: {source}")]
+    #[error("Missing node role {role}")]
+    MissingNodeRole { role: String },
+    #[error("Invalid role configuration: {source}")]
     InvalidRoleConfig {
         source: stackable_operator::product_config_utils::ConfigError,
     },
-    #[error("invalid product configuration: {source}")]
+    #[error("Invalid product configuration: {source}")]
     InvalidProductConfig {
         source: stackable_operator::error::Error,
     },

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -416,11 +416,18 @@ impl Configuration for NameNodeConfig {
 
     fn compute_files(
         &self,
-        _resource: &Self::Configurable,
+        resource: &Self::Configurable,
         _role_name: &str,
-        _file: &str,
+        file: &str,
     ) -> Result<BTreeMap<String, Option<String>>, ConfigError> {
-        Ok(BTreeMap::new())
+        let mut config = BTreeMap::new();
+        if file == HDFS_SITE_XML {
+            if let Some(replication) = &resource.spec.dfs_replication {
+                config.insert(DFS_REPLICATION.to_string(), Some(replication.to_string()));
+            }
+        }
+
+        Ok(config)
     }
 }
 
@@ -445,11 +452,18 @@ impl Configuration for DataNodeConfig {
 
     fn compute_files(
         &self,
-        _resource: &Self::Configurable,
+        resource: &Self::Configurable,
         _role_name: &str,
-        _file: &str,
+        file: &str,
     ) -> Result<BTreeMap<String, Option<String>>, ConfigError> {
-        Ok(BTreeMap::new())
+        let mut config = BTreeMap::new();
+        if file == HDFS_SITE_XML {
+            if let Some(replication) = &resource.spec.dfs_replication {
+                config.insert(DFS_REPLICATION.to_string(), Some(replication.to_string()));
+            }
+        }
+
+        Ok(config)
     }
 }
 

--- a/rust/operator/Cargo.toml
+++ b/rust/operator/Cargo.toml
@@ -19,4 +19,3 @@ thiserror = "1.0"
 tokio = { version = "1.17", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-futures = { version = "0.2", features = ["futures-03"] }
-lazy_static = "1.4"

--- a/rust/operator/src/config.rs
+++ b/rust/operator/src/config.rs
@@ -12,6 +12,7 @@ use std::collections::BTreeMap;
 pub const NAMENODE_DIR: &str = "/data/name";
 pub const DATANODE_DIR: &str = "/data/data";
 pub const JOURNALNODE_DIR: &str = "/data/journal";
+pub const ROOT_DATA_DIR: &str = "/data";
 
 #[derive(Clone)]
 pub struct HdfsNodeDataDirectory {

--- a/rust/operator/src/config.rs
+++ b/rust/operator/src/config.rs
@@ -1,0 +1,189 @@
+use stackable_hdfs_crd::constants::{
+    DEFAULT_JOURNAL_NODE_RPC_PORT, DEFAULT_NAME_NODE_HTTP_PORT, DEFAULT_NAME_NODE_RPC_PORT,
+};
+use stackable_hdfs_crd::HdfsPodRef;
+use std::collections::BTreeMap;
+
+// hdfs-site.xml
+pub const DFS_NAMENODE_NAME_DIR: &str = "dfs.namenode.name.dir";
+pub const DFS_NAMENODE_SHARED_EDITS_DIR: &str = "dfs.namenode.shared.edits.dir";
+pub const DFS_NAMENODE_RPC_ADDRESS: &str = "dfs.namenode.rpc-address";
+pub const DFS_NAMENODE_HTTP_ADDRESS: &str = "dfs.namenode.http-address";
+pub const DFS_DATANODE_DATA_DIR: &str = "dfs.datanode.data.dir";
+pub const DFS_JOURNALNODE_EDITS_DIR: &str = "dfs.journalnode.edits.dir";
+pub const DFS_JOURNALNODE_RPC_ADDRESS: &str = "dfs.journalnode.rpc-address";
+pub const DFS_REPLICATION: &str = "dfs.replication";
+pub const DFS_NAME_SERVICES: &str = "dfs.nameservices";
+
+// core-site.xml
+pub const FS_DEFAULT_FS: &str = "fs.defaultFS";
+pub const HA_ZOOKEEPER_QUORUM: &str = "ha.zookeeper.quorum";
+
+#[derive(Clone, Default)]
+pub struct HdfsSiteConfigBuilder {
+    config: BTreeMap<String, String>,
+}
+
+impl HdfsSiteConfigBuilder {
+    pub fn new() -> Self {
+        HdfsSiteConfigBuilder {
+            config: BTreeMap::new(),
+        }
+    }
+
+    pub fn dfs_namenode_name_dir(&mut self, dir: impl Into<String>) -> &mut Self {
+        self.config.insert(DFS_NAMENODE_NAME_DIR.to_string(), dir);
+        self
+    }
+
+    pub fn dfs_datanode_data_dir(&mut self, dir: impl Into<String>) -> &mut Self {
+        self.config.insert(DFS_DATANODE_DATA_DIR.to_string(), dir);
+        self
+    }
+
+    pub fn dfs_journalnode_edits_dir(&mut self, dir: impl Into<String>) -> &mut Self {
+        self.config
+            .insert(DFS_JOURNALNODE_EDITS_DIR.to_string(), dir);
+        self
+    }
+
+    pub fn dfs_name_services(&mut self, logical_name: impl Into<String>) -> &mut Self {
+        self.config
+            .insert(DFS_NAME_SERVICES.to_string(), logical_name);
+        self
+    }
+
+    pub fn dfs_ha_namenodes(
+        &mut self,
+        logical_name: &str,
+        namenode_podrefs: &[HdfsPodRef],
+    ) -> &mut Self {
+        self.config.insert(
+            format!("dfs.ha.namenodes.{}", logical_name),
+            namenode_podrefs
+                .iter()
+                .map(|nn| nn.pod_name.clone())
+                .collect::<Vec<String>>()
+                .join(","),
+        );
+        self
+    }
+
+    pub fn dfs_namenode_shared_edits_dir(
+        &mut self,
+        journalnode_podrefs: &[HdfsPodRef],
+    ) -> &mut Self {
+        self.config.insert(
+            DFS_NAMENODE_SHARED_EDITS_DIR.to_string(),
+            format!(
+                "qjournal://{}/{}",
+                journalnode_podrefs
+                    .iter()
+                    .map(|jnid| format!(
+                        "{}:{}",
+                        jnid.fqdn(),
+                        jnid.ports
+                            .get(&String::from(DFS_JOURNALNODE_RPC_ADDRESS))
+                            .map_or(DEFAULT_JOURNAL_NODE_RPC_PORT, |p| *p)
+                    ))
+                    .collect::<Vec<_>>()
+                    .join(";"),
+                hdfs.name()
+            ),
+        );
+        self
+    }
+
+    // This required? https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HDFSHighAvailabilityWithNFS.html
+    pub fn dfs_namenode_name_dir_ha(
+        &mut self,
+        logical_name: &str,
+        dir: impl Into<String>,
+        namenode_podrefs: &[HdfsPodRef],
+    ) -> &mut Self {
+        for nn in namenode_podrefs {
+            self.config.insert(
+                format!("{}.{}.{}", DFS_NAMENODE_NAME_DIR, logical_name, nn.pod_name),
+                dir.to_string(),
+            );
+        }
+        self
+    }
+
+    pub fn dfs_namenode_rpc_address_ha(
+        &mut self,
+        logical_name: &str,
+        namenode_podrefs: &[HdfsPodRef],
+    ) -> &mut Self {
+        self.dfs_namenode_address_ha(
+            logical_name,
+            namenode_podrefs,
+            DFS_NAMENODE_RPC_ADDRESS,
+            DEFAULT_NAME_NODE_RPC_PORT,
+        );
+        self
+    }
+
+    pub fn dfs_namenode_http_address_ha(
+        &mut self,
+        logical_name: &str,
+        namenode_podrefs: &[HdfsPodRef],
+    ) -> &mut Self {
+        self.dfs_namenode_address_ha(
+            logical_name,
+            namenode_podrefs,
+            DFS_NAMENODE_HTTP_ADDRESS,
+            DEFAULT_NAME_NODE_HTTP_PORT,
+        );
+        self
+    }
+
+    fn dfs_namenode_address_ha(
+        &mut self,
+        logical_name: &str,
+        namenode_podrefs: &[HdfsPodRef],
+        address: &str,
+        default_port: i32,
+    ) -> &mut Self {
+        for nn in namenode_podrefs {
+            self.config.insert(
+                format!("{}.{}.{}", address, logical_name, nn.pod_name),
+                format!(
+                    "{}:{}",
+                    nn.fqdn(),
+                    nn.ports.get(address).map_or(default_port, |p| *p)
+                ),
+            );
+        }
+        self
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct CoreSiteConfigBuilder {
+    config: BTreeMap<String, String>,
+}
+
+impl CoreSiteConfigBuilder {
+    pub fn new() -> Self {
+        CoreSiteConfigBuilder {
+            config: BTreeMap::new(),
+        }
+    }
+
+    pub fn fs_default_fs(&mut self, logical_name: &str) -> &mut Self {
+        self.config.insert(
+            FS_DEFAULT_FS.to_string(),
+            format!("hdfs://{}/", logical_name),
+        );
+        self
+    }
+
+    pub fn ha_zookeeper_quorum(&mut self) -> &mut Self {
+        self.config.insert(
+            HA_ZOOKEEPER_QUORUM.to_string(),
+            "${env.ZOOKEEPER}".to_string(),
+        );
+        self
+    }
+}

--- a/rust/operator/src/config.rs
+++ b/rust/operator/src/config.rs
@@ -1,24 +1,12 @@
 use stackable_hdfs_crd::constants::{
     DEFAULT_JOURNAL_NODE_RPC_PORT, DEFAULT_NAME_NODE_HTTP_PORT, DEFAULT_NAME_NODE_RPC_PORT,
+    DFS_DATANODE_DATA_DIR, DFS_HA_NAMENODES, DFS_JOURNALNODE_EDITS_DIR,
+    DFS_JOURNALNODE_RPC_ADDRESS, DFS_NAMENODE_HTTP_ADDRESS, DFS_NAMENODE_NAME_DIR,
+    DFS_NAMENODE_RPC_ADDRESS, DFS_NAMENODE_SHARED_EDITS_DIR, DFS_NAME_SERVICES, DFS_REPLICATION,
+    FS_DEFAULT_FS, HA_ZOOKEEPER_QUORUM,
 };
 use stackable_hdfs_crd::HdfsPodRef;
 use std::collections::BTreeMap;
-
-// hdfs-site.xml
-pub const DFS_NAMENODE_NAME_DIR: &str = "dfs.namenode.name.dir";
-pub const DFS_NAMENODE_SHARED_EDITS_DIR: &str = "dfs.namenode.shared.edits.dir";
-pub const DFS_NAMENODE_RPC_ADDRESS: &str = "dfs.namenode.rpc-address";
-pub const DFS_NAMENODE_HTTP_ADDRESS: &str = "dfs.namenode.http-address";
-pub const DFS_DATANODE_DATA_DIR: &str = "dfs.datanode.data.dir";
-pub const DFS_JOURNALNODE_EDITS_DIR: &str = "dfs.journalnode.edits.dir";
-pub const DFS_JOURNALNODE_RPC_ADDRESS: &str = "dfs.journalnode.rpc-address";
-pub const DFS_REPLICATION: &str = "dfs.replication";
-pub const DFS_NAME_SERVICES: &str = "dfs.nameservices";
-pub const DFS_HA_NAMENODES: &str = "dfs.ha.namenodes";
-
-// core-site.xml
-pub const FS_DEFAULT_FS: &str = "fs.defaultFS";
-pub const HA_ZOOKEEPER_QUORUM: &str = "ha.zookeeper.quorum";
 
 // dirs
 pub const NAMENODE_DIR: &str = "/data/name";

--- a/rust/operator/src/config.rs
+++ b/rust/operator/src/config.rs
@@ -64,7 +64,7 @@ impl HdfsSiteConfigBuilder {
     }
 
     pub fn extend(&mut self, properties: &BTreeMap<String, String>) -> &mut Self {
-        self.config.extend(properties);
+        self.config.extend(properties.clone());
         self
     }
 
@@ -237,7 +237,7 @@ impl CoreSiteConfigBuilder {
     }
 
     pub fn extend(&mut self, properties: &BTreeMap<String, String>) -> &mut Self {
-        self.config.extend(properties);
+        self.config.extend(properties.clone());
         self
     }
 

--- a/rust/operator/src/config.rs
+++ b/rust/operator/src/config.rs
@@ -63,6 +63,11 @@ impl HdfsSiteConfigBuilder {
         self
     }
 
+    pub fn extend(&mut self, properties: &BTreeMap<String, String>) -> &mut Self {
+        self.config.extend(properties);
+        self
+    }
+
     pub fn dfs_namenode_name_dir(&mut self) -> &mut Self {
         self.config.insert(
             DFS_NAMENODE_NAME_DIR.to_string(),
@@ -228,6 +233,11 @@ impl CoreSiteConfigBuilder {
             HA_ZOOKEEPER_QUORUM.to_string(),
             "${env.ZOOKEEPER}".to_string(),
         );
+        self
+    }
+
+    pub fn extend(&mut self, properties: &BTreeMap<String, String>) -> &mut Self {
+        self.config.extend(properties);
         self
     }
 

--- a/rust/operator/src/config.rs
+++ b/rust/operator/src/config.rs
@@ -111,6 +111,14 @@ impl HdfsSiteConfigBuilder {
         self
     }
 
+    pub fn dfs_client_failover_proxy_provider(&mut self) -> &mut Self {
+        self.config.insert(
+            format!("dfs.client.failover.proxy.provider.{}", self.logical_name),
+            "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider".to_string(),
+        );
+        self
+    }
+
     pub fn dfs_namenode_shared_edits_dir(
         &mut self,
         journalnode_podrefs: &[HdfsPodRef],

--- a/rust/operator/src/discovery.rs
+++ b/rust/operator/src/discovery.rs
@@ -1,0 +1,87 @@
+use snafu::{OptionExt, ResultExt, Snafu};
+use stackable_hdfs_crd::constants::APP_NAME;
+use stackable_operator::builder::{ConfigMapBuilder, ObjectMetaBuilder};
+use stackable_operator::k8s_openapi::api::core::v1::{ConfigMap, Service};
+use stackable_operator::kube::runtime::reflector::ObjectRef;
+use stackable_operator::kube::{Resource, ResourceExt};
+use stackable_operator::product_config::writer;
+
+#[derive(Snafu, Debug)]
+pub enum Error {
+    #[snafu(display("object {} is missing metadata to build owner reference", zk))]
+    ObjectMissingMetadataForOwnerRef {
+        source: stackable_operator::error::Error,
+        zk: ObjectRef<ZookeeperCluster>,
+    },
+}
+
+/// Builds discovery [`ConfigMap`]s for connecting to a [`ZookeeperCluster`] for all expected scenarios
+pub async fn build_discovery_configmaps(
+    client: &stackable_operator::client::Client,
+    owner: &impl Resource<DynamicType = ()>,
+    zk: &ZookeeperCluster,
+    svc: &Service,
+    chroot: Option<&str>,
+) -> Result<Vec<ConfigMap>, Error> {
+    let name = owner.name();
+    Ok(vec![
+        build_discovery_configmap(&name, owner, zk, chroot, pod_hosts(zk)?)?,
+        build_discovery_configmap(
+            &format!("{}-nodeport", name),
+            owner,
+            zk,
+            chroot,
+            nodeport_hosts(client, svc, "zk").await?,
+        )?,
+    ])
+}
+
+/// Build a discovery [`ConfigMap`] containing information about how to connect to a certain [`ZookeeperCluster`]
+///
+/// `hosts` will usually come from either [`pod_hosts`] or [`nodeport_hosts`].
+fn build_discovery_configmap(
+    name: &str,
+    owner: &impl Resource<DynamicType = ()>,
+    hdfs: HdfsCluster,
+    chroot: Option<&str>,
+    hosts: impl IntoIterator<Item = (impl Into<String>, u16)>,
+) -> Result<ConfigMap, Error> {
+    // Write a connection string of the format that Java ZooKeeper client expects:
+    // "{host1}:{port1},{host2:port2},.../{chroot}"
+    // See https://zookeeper.apache.org/doc/current/apidocs/zookeeper-server/org/apache/zookeeper/ZooKeeper.html#ZooKeeper-java.lang.String-int-org.apache.zookeeper.Watcher-
+    let hosts = hosts
+        .into_iter()
+        .map(|(host, port)| format!("{}:{}", host.into(), port))
+        .collect::<Vec<_>>()
+        .join(",");
+    let mut conn_str = hosts.clone();
+    if let Some(chroot) = chroot {
+        if !chroot.starts_with('/') {
+            return RelativeChrootSnafu { chroot }.fail();
+        }
+        conn_str.push_str(chroot);
+    }
+    ConfigMapBuilder::new()
+        .metadata(
+            ObjectMetaBuilder::new()
+                .name_and_namespace(hdfs)
+                .name(name)
+                .ownerreference_from_resource(owner, None, Some(true))
+                .with_context(|_| ObjectMissingMetadataForOwnerRefSnafu {
+                    zk: ObjectRef::from_obj(hdfs),
+                })?
+                .with_recommended_labels(
+                    hdfs,
+                    APP_NAME,
+                    zk_version(hdfs).unwrap_or("unknown"),
+                    &ZookeeperRole::Server.to_string(),
+                    "discovery",
+                )
+                .build(),
+        )
+        .add_data("hdfs-site.xml", conn_str)
+        .add_data("core-site.xml", hosts)
+        .add_data("HDFS_NAMENODE", chroot.unwrap_or("/"))
+        .build()
+        .context(BuildConfigMapSnafu)
+}

--- a/rust/operator/src/discovery.rs
+++ b/rust/operator/src/discovery.rs
@@ -10,6 +10,8 @@ use stackable_operator::{
     kube::ResourceExt,
 };
 
+/// Creates a discovery config map containing the `hdfs-site.xml` and `core-site.xml`
+/// for clients.
 pub fn build_discovery_configmap(
     hdfs: &HdfsCluster,
     namenode_podrefs: &[HdfsPodRef],
@@ -42,6 +44,8 @@ fn build_discovery_hdfs_site_xml(logical_name: String, namenode_podrefs: &[HdfsP
         .dfs_name_services()
         .dfs_ha_namenodes(namenode_podrefs)
         .dfs_namenode_rpc_address_ha(namenode_podrefs)
+        .dfs_namenode_http_address_ha(namenode_podrefs)
+        .dfs_client_failover_proxy_provider()
         .build_as_xml()
 }
 

--- a/rust/operator/src/discovery.rs
+++ b/rust/operator/src/discovery.rs
@@ -1,87 +1,52 @@
-use snafu::{OptionExt, ResultExt, Snafu};
-use stackable_hdfs_crd::constants::APP_NAME;
-use stackable_operator::builder::{ConfigMapBuilder, ObjectMetaBuilder};
-use stackable_operator::k8s_openapi::api::core::v1::{ConfigMap, Service};
-use stackable_operator::kube::runtime::reflector::ObjectRef;
-use stackable_operator::kube::{Resource, ResourceExt};
-use stackable_operator::product_config::writer;
+use crate::config::{CoreSiteConfigBuilder, HdfsNodeDataDirectory, HdfsSiteConfigBuilder};
+use stackable_hdfs_crd::{
+    constants::{APP_NAME, CORE_SITE_XML, HDFS_SITE_XML},
+    HdfsCluster, HdfsPodRef, HdfsRole,
+};
+use stackable_operator::error::{Error, OperatorResult};
+use stackable_operator::{
+    builder::{ConfigMapBuilder, ObjectMetaBuilder},
+    k8s_openapi::api::core::v1::ConfigMap,
+    kube::ResourceExt,
+};
 
-#[derive(Snafu, Debug)]
-pub enum Error {
-    #[snafu(display("object {} is missing metadata to build owner reference", zk))]
-    ObjectMissingMetadataForOwnerRef {
-        source: stackable_operator::error::Error,
-        zk: ObjectRef<ZookeeperCluster>,
-    },
-}
-
-/// Builds discovery [`ConfigMap`]s for connecting to a [`ZookeeperCluster`] for all expected scenarios
-pub async fn build_discovery_configmaps(
-    client: &stackable_operator::client::Client,
-    owner: &impl Resource<DynamicType = ()>,
-    zk: &ZookeeperCluster,
-    svc: &Service,
-    chroot: Option<&str>,
-) -> Result<Vec<ConfigMap>, Error> {
-    let name = owner.name();
-    Ok(vec![
-        build_discovery_configmap(&name, owner, zk, chroot, pod_hosts(zk)?)?,
-        build_discovery_configmap(
-            &format!("{}-nodeport", name),
-            owner,
-            zk,
-            chroot,
-            nodeport_hosts(client, svc, "zk").await?,
-        )?,
-    ])
-}
-
-/// Build a discovery [`ConfigMap`] containing information about how to connect to a certain [`ZookeeperCluster`]
-///
-/// `hosts` will usually come from either [`pod_hosts`] or [`nodeport_hosts`].
-fn build_discovery_configmap(
-    name: &str,
-    owner: &impl Resource<DynamicType = ()>,
-    hdfs: HdfsCluster,
-    chroot: Option<&str>,
-    hosts: impl IntoIterator<Item = (impl Into<String>, u16)>,
-) -> Result<ConfigMap, Error> {
-    // Write a connection string of the format that Java ZooKeeper client expects:
-    // "{host1}:{port1},{host2:port2},.../{chroot}"
-    // See https://zookeeper.apache.org/doc/current/apidocs/zookeeper-server/org/apache/zookeeper/ZooKeeper.html#ZooKeeper-java.lang.String-int-org.apache.zookeeper.Watcher-
-    let hosts = hosts
-        .into_iter()
-        .map(|(host, port)| format!("{}:{}", host.into(), port))
-        .collect::<Vec<_>>()
-        .join(",");
-    let mut conn_str = hosts.clone();
-    if let Some(chroot) = chroot {
-        if !chroot.starts_with('/') {
-            return RelativeChrootSnafu { chroot }.fail();
-        }
-        conn_str.push_str(chroot);
-    }
+pub fn build_discovery_configmap(
+    hdfs: &HdfsCluster,
+    namenode_podrefs: &[HdfsPodRef],
+) -> OperatorResult<ConfigMap> {
     ConfigMapBuilder::new()
         .metadata(
             ObjectMetaBuilder::new()
                 .name_and_namespace(hdfs)
-                .name(name)
-                .ownerreference_from_resource(owner, None, Some(true))
-                .with_context(|_| ObjectMissingMetadataForOwnerRefSnafu {
-                    zk: ObjectRef::from_obj(hdfs),
-                })?
+                .ownerreference_from_resource(hdfs, None, Some(true))?
                 .with_recommended_labels(
                     hdfs,
                     APP_NAME,
-                    zk_version(hdfs).unwrap_or("unknown"),
-                    &ZookeeperRole::Server.to_string(),
+                    hdfs.hdfs_version()
+                        .map_err(|_| Error::MissingObjectKey { key: "version" })?,
+                    &HdfsRole::NameNode.to_string(),
                     "discovery",
                 )
                 .build(),
         )
-        .add_data("hdfs-site.xml", conn_str)
-        .add_data("core-site.xml", hosts)
-        .add_data("HDFS_NAMENODE", chroot.unwrap_or("/"))
+        .add_data(
+            HDFS_SITE_XML,
+            build_discovery_hdfs_site_xml(hdfs.name(), namenode_podrefs),
+        )
+        .add_data(CORE_SITE_XML, build_discovery_core_site_xml(hdfs.name()))
         .build()
-        .context(BuildConfigMapSnafu)
+}
+
+fn build_discovery_hdfs_site_xml(logical_name: String, namenode_podrefs: &[HdfsPodRef]) -> String {
+    HdfsSiteConfigBuilder::new(logical_name, HdfsNodeDataDirectory::default())
+        .dfs_name_services()
+        .dfs_ha_namenodes(namenode_podrefs)
+        .dfs_namenode_rpc_address_ha(namenode_podrefs)
+        .build_as_xml()
+}
+
+fn build_discovery_core_site_xml(logical_name: String) -> String {
+    CoreSiteConfigBuilder::new(logical_name)
+        .fs_default_fs()
+        .build_as_xml()
 }

--- a/rust/operator/src/hdfs_controller.rs
+++ b/rust/operator/src/hdfs_controller.rs
@@ -214,7 +214,7 @@ fn rolegroup_config_map(
     for (property_name_kind, config) in rolegroup_config {
         match property_name_kind {
             PropertyNameKind::File(file_name) if file_name == HDFS_SITE_XML => {
-                let builder =
+                hdfs_site_xml =
                     HdfsSiteConfigBuilder::new(hdfs.name(), HdfsNodeDataDirectory::default())
                         // IMPORTANT: these folders must be under the volume mount point, otherwise they will not
                         // be formatted by the namenode, or used by the other services.
@@ -233,21 +233,18 @@ fn rolegroup_config_map(
                         .add("dfs.ha.fencing.methods", "shell(/bin/true)")
                         .add("dfs.ha.nn.not-become-active-in-safemode", "true")
                         .add("dfs.ha.automatic-failover.enabled", "true")
-                        .add("dfs.ha.namenode.id", "${env.POD_NAME}");
-
-                // overrides
-                builder.extend(config);
-                hdfs_site_xml = builder.build_as_xml();
+                        .add("dfs.ha.namenode.id", "${env.POD_NAME}")
+                        // the extend with config must come last in order to have overrides working!!!
+                        .extend(config)
+                        .build_as_xml();
             }
             PropertyNameKind::File(file_name) if file_name == CORE_SITE_XML => {
-                let builder = CoreSiteConfigBuilder::new(hdfs.name())
+                core_site_xml = CoreSiteConfigBuilder::new(hdfs.name())
                     .fs_default_fs()
-                    .ha_zookeeper_quorum();
-
-                // overrides
-                builder.extend(config);
-
-                core_site_xml = builder.build_as_xml()
+                    .ha_zookeeper_quorum()
+                    // the extend with config must come last in order to have overrides working!!!
+                    .extend(config)
+                    .build_as_xml();
             }
             _ => {}
         }

--- a/rust/operator/src/hdfs_controller.rs
+++ b/rust/operator/src/hdfs_controller.rs
@@ -214,7 +214,7 @@ fn rolegroup_config_map(
     for (property_name_kind, config) in rolegroup_config {
         match property_name_kind {
             PropertyNameKind::File(file_name) if file_name == HDFS_SITE_XML => {
-                hdfs_site_xml =
+                let builder =
                     HdfsSiteConfigBuilder::new(hdfs.name(), HdfsNodeDataDirectory::default())
                         // IMPORTANT: these folders must be under the volume mount point, otherwise they will not
                         // be formatted by the namenode, or used by the other services.
@@ -233,14 +233,21 @@ fn rolegroup_config_map(
                         .add("dfs.ha.fencing.methods", "shell(/bin/true)")
                         .add("dfs.ha.nn.not-become-active-in-safemode", "true")
                         .add("dfs.ha.automatic-failover.enabled", "true")
-                        .add("dfs.ha.namenode.id", "${env.POD_NAME}")
-                        .build_as_xml();
+                        .add("dfs.ha.namenode.id", "${env.POD_NAME}");
+
+                // overrides
+                builder.extend(config);
+                hdfs_site_xml = builder.build_as_xml();
             }
             PropertyNameKind::File(file_name) if file_name == CORE_SITE_XML => {
-                core_site_xml = CoreSiteConfigBuilder::new(hdfs.name())
+                let builder = CoreSiteConfigBuilder::new(hdfs.name())
                     .fs_default_fs()
-                    .ha_zookeeper_quorum()
-                    .build_as_xml();
+                    .ha_zookeeper_quorum();
+
+                // overrides
+                builder.extend(config);
+
+                core_site_xml = builder.build_as_xml()
             }
             _ => {}
         }

--- a/rust/operator/src/lib.rs
+++ b/rust/operator/src/lib.rs
@@ -1,5 +1,6 @@
 //mod discovery;
 mod config;
+mod discovery;
 mod hdfs_controller;
 mod pod_svc_controller;
 

--- a/rust/operator/src/lib.rs
+++ b/rust/operator/src/lib.rs
@@ -1,3 +1,5 @@
+//mod discovery;
+mod config;
 mod hdfs_controller;
 mod pod_svc_controller;
 

--- a/rust/operator/src/lib.rs
+++ b/rust/operator/src/lib.rs
@@ -1,4 +1,3 @@
-//mod discovery;
 mod config;
 mod discovery;
 mod hdfs_controller;


### PR DESCRIPTION
## Description

- adapted scripts for formatting namenodes
- code clean up

based on PR https://github.com/stackabletech/hdfs-operator/pull/150

closes https://github.com/stackabletech/hdfs-operator/issues/153 https://github.com/stackabletech/hdfs-operator/issues/147

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
