### PR TITLE
[Merged by Bors] - Request more storage in tests due to the required minimal size on Ionos managed k8s

### DIFF
--- a/tests/templates/kuttl/fs-ops/00-install-zk.yaml.j2
+++ b/tests/templates/kuttl/fs-ops/00-install-zk.yaml.j2
@@ -5,6 +5,11 @@ metadata:
   name: hdfs-zk
 spec:
   servers:
+    config:
+      resources:
+        storage:
+          data:
+            capacity: '2Gi'
     roleGroups:
       default:
         replicas: 1

--- a/tests/templates/kuttl/fs-ops/01-install-hdfs.yaml.j2
+++ b/tests/templates/kuttl/fs-ops/01-install-hdfs.yaml.j2
@@ -32,7 +32,7 @@ spec:
       resources:
         storage:
           data:
-            capacity: 256Mi
+            capacity: 2Gi
     roleGroups:
       default:
         selector:
@@ -44,7 +44,7 @@ spec:
       resources:
         storage:
           data:
-            capacity: 1Gi
+            capacity: 2Gi
     roleGroups:
       default:
         selector:
@@ -56,7 +56,7 @@ spec:
       resources:
         storage:
           data:
-            capacity: 512Mi
+            capacity: 2Gi
     roleGroups:
       default:
         selector:


### PR DESCRIPTION
# Description

When running these tests on Ionos managed k8s provisioning of the PVCs failed with this error:

message: 'failed to provision volume with StorageClass "ionos-enterprise-hdd": rpc
  error: code = OutOfRange desc = Requested size 536870912 must be between 1073741824
  and 4398046511104 bytes'

This PR increases the size of all requested PVCs to 2Gi to see if the tests finish then.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
