### PR TITLE
[Merged by Bors] - Add recommended labels to NodePort services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Include chart name when installing with a custom release name ([#205])
-- Added OpenShift compatiblity ([#225])
+- Added OpenShift compatibility ([#225])
+- Add recommended labels to NodePort services ([#240])
 
 [#205]: https://github.com/stackabletech/hdfs-operator/pull/205
 [#225]: https://github.com/stackabletech/hdfs-operator/pull/225
+[#240]: https://github.com/stackabletech/hdfs-operator/pull/240
 
 ## [0.4.0] - 2022-06-30
 

--- a/rust/crd/src/error.rs
+++ b/rust/crd/src/error.rs
@@ -100,6 +100,11 @@ pub enum Error {
     PodHasNoSpec { name: String },
     #[error("Pod [{name}] has no container named [{role}]")]
     PodHasNoContainer { name: String, role: String },
+    #[error("Failed to build ownerreference of pod [{name}]")]
+    PodOwnerReference {
+        source: stackable_operator::error::Error,
+        name: String,
+    },
 
     #[error("Object has no associated namespace.")]
     NoNamespaceContext,


### PR DESCRIPTION
# Description

Needed, so that stackablectl can list the available services
```
stackablectl services list 
 PRODUCT    NAME       NAMESPACE  ENDPOINTS                                               EXTRA INFOS 
                                                                                                      
 hbase      hbase      default    regionserver                  172.18.0.5:32282                      
                                  ui                            http://172.18.0.5:31527               
                                  metrics                       172.18.0.5:31081                      
                                                                                                      
 hdfs       hdfs       default    datanode-default-0-metrics    172.18.0.2:31441                      
                                  datanode-default-0-data       172.18.0.2:32432                      
                                  datanode-default-0-http       http://172.18.0.2:30758               
                                  datanode-default-0-ipc        172.18.0.2:32323                      
                                  journalnode-default-0-metrics 172.18.0.5:31123                      
                                  journalnode-default-0-http    http://172.18.0.5:30038               
                                  journalnode-default-0-https   https://172.18.0.5:31996              
                                  journalnode-default-0-rpc     172.18.0.5:30080                      
                                  namenode-default-0-metrics    172.18.0.2:32753                      
                                  namenode-default-0-http       http://172.18.0.2:32475               
                                  namenode-default-0-rpc        172.18.0.2:31639                      
                                  namenode-default-1-metrics    172.18.0.4:32202                      
                                  namenode-default-1-http       http://172.18.0.4:31486               
                                  namenode-default-1-rpc        172.18.0.4:31874                      
                                                                                                      
 zookeeper  zookeeper  default    zk                            172.18.0.4:32469
```

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
