### PR TITLE
[Merged by Bors] - Set specified resource request and limit on namenode main container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ All notable changes to this project will be documented in this file.
 [#249]: https://github.com/stackabletech/hdfs-operator/pull/249
 [#250]: https://github.com/stackabletech/hdfs-operator/pull/250
 
+### Fixed
+
+- Set specified resource request and limit on namenode main container ([#259])
+
+[#259]: https://github.com/stackabletech/hdfs-operator/pull/259
+
 ## [0.5.0] - 2022-09-06
 
 ### Changed

--- a/rust/operator/src/hdfs_controller.rs
+++ b/rust/operator/src/hdfs_controller.rs
@@ -540,6 +540,7 @@ fn namenode_containers(
             env: Some(env),
             readiness_probe: Some(tcp_socket_action_probe(SERVICE_PORT_NAME_RPC, 10, 10)),
             liveness_probe: Some(tcp_socket_action_probe(SERVICE_PORT_NAME_RPC, 10, 10)),
+            resources: Some(resources.clone()),
             ..hadoop_container.clone()
         },
         // Note that we don't add the HADOOP_OPTS / HDFS_NAMENODE_OPTS env var to this container (zkfc)


### PR DESCRIPTION
Also created ticket for tests https://github.com/stackabletech/hdfs-operator/issues/260

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
