### PR TITLE
[Merged by Bors] - Remove the "--debug" flag in container start up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,7 @@ All notable changes to this project will be documented in this file.
 
 - `operator-rs` `0.36.0` -> `0.37.0` ([#326]).
 - [Breaking] Moved top level config option to `clusterConfig` ([#326]).
-
-### Removed
-
-- Removed `--debug` from container start command ([#332]).
+- The `--debug` flag for HDFS container arguments now depends on logging settings ([#332]).
 
 [#319]: https://github.com/stackabletech/hdfs-operator/pull/319
 [#326]: https://github.com/stackabletech/hdfs-operator/pull/326

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,14 @@ All notable changes to this project will be documented in this file.
 - `operator-rs` `0.36.0` -> `0.37.0` ([#326]).
 - [Breaking] Moved top level config option to `clusterConfig` ([#326]).
 
+### Removed
+
+- `--debug` from container start command ([#332]).
+
 [#319]: https://github.com/stackabletech/hdfs-operator/pull/319
 [#326]: https://github.com/stackabletech/hdfs-operator/pull/326
 [#328]: https://github.com/stackabletech/hdfs-operator/pull/328
+[#332]: https://github.com/stackabletech/hdfs-operator/pull/332
 
 ## [23.1.0] - 2023-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ All notable changes to this project will be documented in this file.
 
 - `operator-rs` `0.36.0` -> `0.37.0` ([#326]).
 - [Breaking] Moved top level config option to `clusterConfig` ([#326]).
-- The `--debug` flag for HDFS container arguments now depends on logging settings ([#332]).
+
+### Removed
+
+- Removed the `--debug` flag for HDFS container start up ([#332]).
 
 [#319]: https://github.com/stackabletech/hdfs-operator/pull/319
 [#326]: https://github.com/stackabletech/hdfs-operator/pull/326

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 
-- `--debug` from container start command ([#332]).
+- Removed `--debug` from container start command ([#332]).
 
 [#319]: https://github.com/stackabletech/hdfs-operator/pull/319
 [#326]: https://github.com/stackabletech/hdfs-operator/pull/326

--- a/rust/operator/src/container.rs
+++ b/rust/operator/src/container.rs
@@ -27,7 +27,6 @@ use stackable_hdfs_crd::{
     storage::DataNodeStorageConfig,
     DataNodeContainer, HdfsPodRef, HdfsRole, MergedConfig, NameNodeContainer,
 };
-use stackable_operator::product_logging::spec::LogLevel;
 use stackable_operator::{
     builder::{ContainerBuilder, PodBuilder, VolumeBuilder, VolumeMountBuilder},
     commons::product_image_selection::ResolvedProductImage,
@@ -46,7 +45,7 @@ use stackable_operator::{
         ConfigMapLogConfig, ContainerLogConfig, ContainerLogConfigChoice, CustomContainerLogConfig,
     },
 };
-use std::{cmp, collections::BTreeMap, str::FromStr};
+use std::{collections::BTreeMap, str::FromStr};
 use strum::{Display, EnumDiscriminants, IntoStaticStr};
 
 #[derive(Snafu, Debug, EnumDiscriminants)]
@@ -364,24 +363,10 @@ impl ContainerConfig {
                     merged_config.hdfs_logging(),
                 ));
 
-                // If max(root_log_level, console_log_level) is lower (where TRACE is lowest and
-                // NONE is highest) than INFO (e.g. DEBUG, TRACE), add the `--debug` flag to the
-                // start arguments to get additional console output (this is not collected by vector).
-                // This prints startup scripts debug settings like
-                // DEBUG: HADOOP_CONF_DIR=/stackable/config/namenode
-                args.push(
-                    if use_start_up_script_debug(&merged_config.hdfs_logging()) {
-                        format!(
-                            "{hadoop_home}/bin/hdfs --debug {role}",
-                            hadoop_home = Self::HADOOP_HOME,
-                        )
-                    } else {
-                        format!(
-                            "{hadoop_home}/bin/hdfs {role}",
-                            hadoop_home = Self::HADOOP_HOME,
-                        )
-                    },
-                );
+                args.push(format!(
+                    "{hadoop_home}/bin/hdfs {role}",
+                    hadoop_home = Self::HADOOP_HOME,
+                ));
             }
             ContainerConfig::Zkfc { .. } => {
                 if let Some(container_config) = merged_config.zkfc_logging() {
@@ -885,25 +870,6 @@ impl ContainerConfig {
             }
         }
         volumes
-    }
-}
-
-/// Determine if the Hadoop start up scripts should log additional DEBUG information.
-fn use_start_up_script_debug(log_config: &ContainerLogConfig) -> bool {
-    if let ContainerLogConfig {
-        choice: Some(ContainerLogConfigChoice::Automatic(log_config)),
-    } = log_config
-    {
-        let root_log_level = log_config.root_log_level();
-        let console_log_level = log_config
-            .console
-            .as_ref()
-            .and_then(|console| console.level)
-            .unwrap_or_default();
-
-        cmp::max(root_log_level, console_log_level) < LogLevel::INFO
-    } else {
-        false
     }
 }
 

--- a/rust/operator/src/container.rs
+++ b/rust/operator/src/container.rs
@@ -364,7 +364,7 @@ impl ContainerConfig {
                 ));
 
                 args.push(format!(
-                    "{hadoop_home}/bin/hdfs --debug {role}",
+                    "{hadoop_home}/bin/hdfs {role}",
                     hadoop_home = Self::HADOOP_HOME,
                 ));
             }


### PR DESCRIPTION
# Description

The `--debug` flag in the HDFS container command now depends on logging settings. However, these message are not collected by vector currently.

@siegfriedweber any opinions?

fixes https://github.com/stackabletech/hdfs-operator/issues/330

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
