### PR TITLE
[Merged by Bors] - run as root group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ All notable changes to this project will be documented in this file.
 - Operator-rs: `0.40.2` -> `0.41.0` ([#349]).
 - Use 0.0.0-dev product images for testing ([#351])
 - Use testing-tools 0.2.0 ([#351])
+- Run as root group ([#353]).
 
 [#349]: https://github.com/stackabletech/hdfs-operator/pull/349
 [#350]: https://github.com/stackabletech/hdfs-operator/pull/350
 [#351]: https://github.com/stackabletech/hdfs-operator/pull/351
+[#353]: https://github.com/stackabletech/hdfs-operator/pull/353
 
 ## [23.4.0] - 2023-04-17
 

--- a/rust/crd/src/constants.rs
+++ b/rust/crd/src/constants.rs
@@ -60,3 +60,5 @@ pub const JOURNALNODE_ROOT_DATA_DIR: &str = "/stackable/data/journalnode";
 // ending up with a location of `/stackable/hadoop/data`
 pub const DATANODE_ROOT_DATA_DIR_PREFIX: &str = "/stackable/data/";
 pub const DATANODE_ROOT_DATA_DIR_SUFFIX: &str = "/datanode";
+
+pub const HDFS_UID: i64 = 1000;

--- a/rust/operator/src/hdfs_controller.rs
+++ b/rust/operator/src/hdfs_controller.rs
@@ -521,8 +521,8 @@ fn rolegroup_statefulset(
     .service_account_name(service_account_name(APP_NAME))
     .security_context(
         PodSecurityContextBuilder::new()
-            .run_as_user(1000)
-            .run_as_group(1000)
+            .run_as_user(HDFS_UID)
+            .run_as_group(0)
             .fs_group(1000)
             .build(),
     );


### PR DESCRIPTION
# Description

run as root group instead of 1000.

Subset of tests on openshift:

```
--- PASS: kuttl (2279.12s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/cluster-operation_hadoop-latest-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev (332.31s)
        --- PASS: kuttl/harness/orphaned-resources_hadoop-latest-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev (174.34s)
        --- PASS: kuttl/harness/smoke_hadoop-3.3.4-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_number-of-datanodes-2_datanode-pvcs-2hdd-1ssd_listener-class-cluster-internal (212.42s)
        --- PASS: kuttl/harness/logging_hadoop-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev (268.98s)
        --- PASS: kuttl/harness/smoke_hadoop-3.3.4-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_number-of-datanodes-2_datanode-pvcs-default_listener-class-external-unstable (199.71s)
        --- PASS: kuttl/harness/smoke_hadoop-3.3.4-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_number-of-datanodes-2_datanode-pvcs-default_listener-class-cluster-internal (206.48s)
        --- PASS: kuttl/harness/smoke_hadoop-3.3.4-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_number-of-datanodes-2_datanode-pvcs-2hdd-1ssd_listener-class-external-unstable (210.80s)
        --- PASS: kuttl/harness/smoke_hadoop-3.3.4-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_number-of-datanodes-1_datanode-pvcs-default_listener-class-cluster-internal (175.10s)
        --- PASS: kuttl/harness/smoke_hadoop-3.3.4-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_number-of-datanodes-1_datanode-pvcs-default_listener-class-external-unstable (163.84s)
        --- PASS: kuttl/harness/smoke_hadoop-3.3.4-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_number-of-datanodes-1_datanode-pvcs-2hdd-1ssd_listener-class-external-unstable (160.07s)
        --- PASS: kuttl/harness/smoke_hadoop-3.3.4-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_number-of-datanodes-1_datanode-pvcs-2hdd-1ssd_listener-class-cluster-internal (164.20s)
PASS
```


<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
