### PR TITLE
Add missing crd defaults to 23.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ All notable changes to this project will be documented in this file.
 
 ## [23.4.1] - 2023-05-17
 
+### Added
+
+- Missing CRD defaults for `status.conditions` field ([#354]).
+
 ### Changed
 
 - Run as root group ([#353]).
 
 [#353]: https://github.com/stackabletech/hdfs-operator/pull/353
+[#354]: https://github.com/stackabletech/hdfs-operator/pull/354
 
 ## [23.4.0] - 2023-04-17
 

--- a/deploy/helm/hdfs-operator/crds/crds.yaml
+++ b/deploy/helm/hdfs-operator/crds/crds.yaml
@@ -4228,6 +4228,7 @@ spec:
               nullable: true
               properties:
                 conditions:
+                  default: []
                   items:
                     properties:
                       lastTransitionTime:
@@ -4269,8 +4270,6 @@ spec:
                       - type
                     type: object
                   type: array
-              required:
-                - conditions
               type: object
           required:
             - spec

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -1105,6 +1105,7 @@ impl Configuration for JournalNodeConfigFragment {
 #[derive(Clone, Default, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HdfsClusterStatus {
+    #[serde(default)]
     pub conditions: Vec<ClusterCondition>,
 }
 


### PR DESCRIPTION
# Description

Add missing crd defaults

(cherry picked from commit 9ed06b098131731ddb8961dadca4c503f540c90d)

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
