### PR TITLE
[Merged by Bors] - Remove outdated README

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,0 @@
-
-The following scripts are incuded here:
-
-- `stackable/bin/start-namenode` : A wrapper script for Hadoop's `hdfs` script that ensures that the namenode's directory is formatted before the process is started. This script is packaged with the hadoop package and it's set as container's command line program for the namenode pod.
-
-


### PR DESCRIPTION

# Description

The only script described in the README has been removed in https://github.com/stackabletech/docker-images/commit/65236c4d4567593fdd42f9f2859b8c0e292917e8#diff-2718f29b4b0d0482fa9f95369364c39f3e502f856ae62d571430c0a7784fce14 so I assume this file can go

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->


Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
