### PR TITLE
[Merged by Bors] - nightly test suite

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -64,13 +64,21 @@ tests:
       - hadoop-latest
       - zookeeper-latest
 suites:
-  - name: latest
+  - name: nightly
+    patch:
+      - dimensions:
+          - name: hadoop
+            expr: last
+          - name: number-of-datanodes
+            expr: "2"
+          - name: datanode-pvcs
+            expr: "2hdd-1ssd"
+  - name: smoke-latest
+    select:
+      - smoke
     patch:
       - dimensions:
           - expr: last
-  - name: smoke
-    select:
-      - smoke
   - name: openshift
     patch:
       - dimensions:
@@ -78,3 +86,9 @@ suites:
       - dimensions:
           - name: openshift
             expr: "true"
+          - name: hadoop
+            expr: last
+          - name: number-of-datanodes
+            expr: "2"
+          - name: datanode-pvcs
+            expr: "2hdd-1ssd"


### PR DESCRIPTION
Part of https://github.com/stackabletech/ci/issues/62
```
(stackable) ➜  hdfs-operator git:(feat/nightly-suite) ✗ beku -s nightly     
INFO:root:Expanding test case id [smoke_hadoop-3.3.4-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_number-of-datanodes-2_datanode-pvcs-2hdd-1ssd_listener-class-cluster-internal]
INFO:root:Expanding test case id [smoke_hadoop-3.3.4-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_number-of-datanodes-2_datanode-pvcs-2hdd-1ssd_listener-class-external-unstable]
INFO:root:Expanding test case id [kerberos_hadoop-latest-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit]
INFO:root:Expanding test case id [kerberos_hadoop-latest-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_kerberos-realm-PROD.MYCORP_kerberos-backend-mit]
INFO:root:Expanding test case id [orphaned-resources_hadoop-latest-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [logging_hadoop-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [cluster-operation_hadoop-latest-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
```
```
(stackable) ➜  hdfs-operator git:(feat/nightly-suite) ✗ beku -s smoke-latest
INFO:root:Expanding test case id [smoke_hadoop-3.3.4-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_number-of-datanodes-2_datanode-pvcs-2hdd-1ssd_listener-class-external-unstable]
```
```
(stackable) ➜  hdfs-operator git:(feat/nightly-suite) ✗ beku -s openshift   
INFO:root:Expanding test case id [smoke_hadoop-3.3.4-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_number-of-datanodes-2_datanode-pvcs-2hdd-1ssd_listener-class-external-unstable]
INFO:root:Expanding test case id [kerberos_hadoop-latest-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_kerberos-realm-PROD.MYCORP_kerberos-backend-mit]
INFO:root:Expanding test case id [orphaned-resources_hadoop-latest-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [logging_hadoop-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [cluster-operation_hadoop-latest-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
```
