### PR TITLE
JVM config overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Default stackableVersion to operator version ([#381]).
+- Configuration overrides for the JVM security properties, such as DNS caching ([#384]).
 
 ### Changed
 
@@ -15,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 [#378]: https://github.com/stackabletech/hdfs-operator/pull/378
 [#381]: https://github.com/stackabletech/hdfs-operator/pull/381
+[#384]: https://github.com/stackabletech/hdfs-operator/pull/384
 
 ## [23.7.0] - 2023-07-14
 
@@ -84,7 +86,6 @@ All notable changes to this project will be documented in this file.
 [#340]: https://github.com/stackabletech/hdfs-operator/pull/340
 [#341]: https://github.com/stackabletech/hdfs-operator/pull/341
 [#342]: https://github.com/stackabletech/hdfs-operator/pull/342
-
 
 ## [23.1.0] - 2023-01-23
 

--- a/deploy/config-spec/properties.yaml
+++ b/deploy/config-spec/properties.yaml
@@ -20,7 +20,7 @@ properties:
         min: "0"
       recommendedValues:
         - fromVersion: "0.0.0"
-          value: "5"
+          value: "30"
       roles:
         - name: "namenode"
           required: true
@@ -39,7 +39,7 @@ properties:
         min: "0"
       recommendedValues:
         - fromVersion: "0.0.0"
-          value: "5"
+          value: "30"
       roles:
         - name: "datanode"
           required: true
@@ -58,7 +58,7 @@ properties:
         min: "0"
       recommendedValues:
         - fromVersion: "0.0.0"
-          value: "5"
+          value: "30"
       roles:
         - name: "journalnode"
           required: true
@@ -278,4 +278,3 @@ properties:
           required: false
       asOfVersion: "0.0.0"
       description: "The address and port the JournalNode HTTPS server listens on. If the port is 0 then the server will start on a free port."
-

--- a/deploy/config-spec/properties.yaml
+++ b/deploy/config-spec/properties.yaml
@@ -11,6 +11,120 @@ spec:
 properties:
   - property:
       propertyNames:
+        - name: "networkaddress.cache.ttl"
+          kind:
+            type: "file"
+            file: "security.properties"
+      datatype:
+        type: "integer"
+        min: "0"
+      recommendedValues:
+        - fromVersion: "0.0.0"
+          value: "5"
+      roles:
+        - name: "namenode"
+          required: true
+      asOfVersion: "0.0.0"
+      comment: "TTL for successfully resolved domain names."
+      description: "TTL for successfully resolved domain names."
+
+  - property:
+      propertyNames:
+        - name: "networkaddress.cache.ttl"
+          kind:
+            type: "file"
+            file: "security.properties"
+      datatype:
+        type: "integer"
+        min: "0"
+      recommendedValues:
+        - fromVersion: "0.0.0"
+          value: "5"
+      roles:
+        - name: "datanode"
+          required: true
+      asOfVersion: "0.0.0"
+      comment: "TTL for successfully resolved domain names."
+      description: "TTL for successfully resolved domain names."
+
+  - property:
+      propertyNames:
+        - name: "networkaddress.cache.ttl"
+          kind:
+            type: "file"
+            file: "security.properties"
+      datatype:
+        type: "integer"
+        min: "0"
+      recommendedValues:
+        - fromVersion: "0.0.0"
+          value: "5"
+      roles:
+        - name: "journalnode"
+          required: true
+      asOfVersion: "0.0.0"
+      comment: "TTL for successfully resolved domain names."
+      description: "TTL for successfully resolved domain names."
+
+  - property:
+      propertyNames:
+        - name: "networkaddress.cache.negative.ttl"
+          kind:
+            type: "file"
+            file: "security.properties"
+      datatype:
+        type: "integer"
+        min: "0"
+      recommendedValues:
+        - fromVersion: "0.0.0"
+          value: "0"
+      roles:
+        - name: "namenode"
+          required: true
+      asOfVersion: "0.0.0"
+      comment: "TTL for domain names that cannot be resolved."
+      description: "TTL for domain names that cannot be resolved."
+
+  - property:
+      propertyNames:
+        - name: "networkaddress.cache.negative.ttl"
+          kind:
+            type: "file"
+            file: "security.properties"
+      datatype:
+        type: "integer"
+        min: "0"
+      recommendedValues:
+        - fromVersion: "0.0.0"
+          value: "0"
+      roles:
+        - name: "datanode"
+          required: true
+      asOfVersion: "0.0.0"
+      comment: "TTL for domain names that cannot be resolved."
+      description: "TTL for domain names that cannot be resolved."
+
+  - property:
+      propertyNames:
+        - name: "networkaddress.cache.negative.ttl"
+          kind:
+            type: "file"
+            file: "security.properties"
+      datatype:
+        type: "integer"
+        min: "0"
+      recommendedValues:
+        - fromVersion: "0.0.0"
+          value: "0"
+      roles:
+        - name: "journalnode"
+          required: true
+      asOfVersion: "0.0.0"
+      comment: "TTL for domain names that cannot be resolved."
+      description: "TTL for domain names that cannot be resolved."
+
+  - property:
+      propertyNames:
         - name: "dfs.namenode.name.dir"
           kind:
             type: "file"

--- a/deploy/helm/hdfs-operator/configs/properties.yaml
+++ b/deploy/helm/hdfs-operator/configs/properties.yaml
@@ -20,7 +20,7 @@ properties:
         min: "0"
       recommendedValues:
         - fromVersion: "0.0.0"
-          value: "5"
+          value: "30"
       roles:
         - name: "namenode"
           required: true
@@ -39,7 +39,7 @@ properties:
         min: "0"
       recommendedValues:
         - fromVersion: "0.0.0"
-          value: "5"
+          value: "30"
       roles:
         - name: "datanode"
           required: true
@@ -58,7 +58,7 @@ properties:
         min: "0"
       recommendedValues:
         - fromVersion: "0.0.0"
-          value: "5"
+          value: "30"
       roles:
         - name: "journalnode"
           required: true
@@ -278,4 +278,3 @@ properties:
           required: false
       asOfVersion: "0.0.0"
       description: "The address and port the JournalNode HTTPS server listens on. If the port is 0 then the server will start on a free port."
-

--- a/deploy/helm/hdfs-operator/configs/properties.yaml
+++ b/deploy/helm/hdfs-operator/configs/properties.yaml
@@ -11,6 +11,120 @@ spec:
 properties:
   - property:
       propertyNames:
+        - name: "networkaddress.cache.ttl"
+          kind:
+            type: "file"
+            file: "security.properties"
+      datatype:
+        type: "integer"
+        min: "0"
+      recommendedValues:
+        - fromVersion: "0.0.0"
+          value: "5"
+      roles:
+        - name: "namenode"
+          required: true
+      asOfVersion: "0.0.0"
+      comment: "TTL for successfully resolved domain names."
+      description: "TTL for successfully resolved domain names."
+
+  - property:
+      propertyNames:
+        - name: "networkaddress.cache.ttl"
+          kind:
+            type: "file"
+            file: "security.properties"
+      datatype:
+        type: "integer"
+        min: "0"
+      recommendedValues:
+        - fromVersion: "0.0.0"
+          value: "5"
+      roles:
+        - name: "datanode"
+          required: true
+      asOfVersion: "0.0.0"
+      comment: "TTL for successfully resolved domain names."
+      description: "TTL for successfully resolved domain names."
+
+  - property:
+      propertyNames:
+        - name: "networkaddress.cache.ttl"
+          kind:
+            type: "file"
+            file: "security.properties"
+      datatype:
+        type: "integer"
+        min: "0"
+      recommendedValues:
+        - fromVersion: "0.0.0"
+          value: "5"
+      roles:
+        - name: "journalnode"
+          required: true
+      asOfVersion: "0.0.0"
+      comment: "TTL for successfully resolved domain names."
+      description: "TTL for successfully resolved domain names."
+
+  - property:
+      propertyNames:
+        - name: "networkaddress.cache.negative.ttl"
+          kind:
+            type: "file"
+            file: "security.properties"
+      datatype:
+        type: "integer"
+        min: "0"
+      recommendedValues:
+        - fromVersion: "0.0.0"
+          value: "0"
+      roles:
+        - name: "namenode"
+          required: true
+      asOfVersion: "0.0.0"
+      comment: "TTL for domain names that cannot be resolved."
+      description: "TTL for domain names that cannot be resolved."
+
+  - property:
+      propertyNames:
+        - name: "networkaddress.cache.negative.ttl"
+          kind:
+            type: "file"
+            file: "security.properties"
+      datatype:
+        type: "integer"
+        min: "0"
+      recommendedValues:
+        - fromVersion: "0.0.0"
+          value: "0"
+      roles:
+        - name: "datanode"
+          required: true
+      asOfVersion: "0.0.0"
+      comment: "TTL for domain names that cannot be resolved."
+      description: "TTL for domain names that cannot be resolved."
+
+  - property:
+      propertyNames:
+        - name: "networkaddress.cache.negative.ttl"
+          kind:
+            type: "file"
+            file: "security.properties"
+      datatype:
+        type: "integer"
+        min: "0"
+      recommendedValues:
+        - fromVersion: "0.0.0"
+          value: "0"
+      roles:
+        - name: "journalnode"
+          required: true
+      asOfVersion: "0.0.0"
+      comment: "TTL for domain names that cannot be resolved."
+      description: "TTL for domain names that cannot be resolved."
+
+  - property:
+      propertyNames:
         - name: "dfs.namenode.name.dir"
           kind:
             type: "file"

--- a/docs/modules/hdfs/pages/usage-guide/configuration-environment-overrides.adoc
+++ b/docs/modules/hdfs/pages/usage-guide/configuration-environment-overrides.adoc
@@ -7,7 +7,14 @@ IMPORTANT: Overriding certain properties can lead to faulty clusters. In general
 
 == Configuration Properties
 
-For a role or role group, at the same level of `config`, you can specify `configOverrides` for the `hdfs-site.xml` and `core-site.xml`. For example, if you want to set additional properties on the namenode servers, adapt the `nameNodes` section of the cluster resource like so:
+For a role or role group, at the same level of `config`, you can specify `configOverrides` for the the following files:
+
+- `hdfs-site.xml`
+- `core-site.xml`
+- `security.properties`
+
+
+For example, if you want to set additional properties on the namenode servers, adapt the `nameNodes` section of the cluster resource like so:
 
 [source,yaml]
 ----
@@ -42,6 +49,35 @@ nameNodes:
 All override property values must be strings. The properties will be formatted and escaped correctly into the XML file.
 
 For a full list of configuration options we refer to the Apache Hdfs documentation for https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml[hdfs-site.xml] and https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/core-default.xml[core-site.xml]
+
+=== The security.properties file
+
+The `security.properties` file is used to configure JVM security properties. It is very seldom that users need to tweak any of these, but there is one use-case that stands out, and that users need to be aware of: the JVM DNS cache.
+
+The JVM manages it's own cache of successfully resolved host names as well as a cache of host names that cannot be resolved. Some products of the Stackable platform are very sensible to the contents of these caches and their performance is heavily affected by them. As of version 3.3.4 HDFS performs poorly if the positive cache is disabled. To cache resolved host names, and thus speeding up Hbase queries you can configure the TTL of entries in the positive cache like this:
+
+[source,yaml]
+----
+  namenodes:
+    configOverrides:
+      security.properties:
+        networkaddress.cache.ttl: "30"
+        networkaddress.cache.negative.ttl: "0"
+  datanodes:
+    configOverrides:
+      security.properties:
+        networkaddress.cache.ttl: "30"
+        networkaddress.cache.negative.ttl: "0"
+  journalnodes:
+    configOverrides:
+      security.properties:
+        networkaddress.cache.ttl: "30"
+        networkaddress.cache.negative.ttl: "0"
+----
+
+NOTE: The operator configures DNS caching by default as shown in the example above.
+
+For details on the JVM security see https://docs.oracle.com/en/java/javase/11/security/java-security-overview1.html
 
 
 == Environment Variables

--- a/docs/modules/hdfs/pages/usage-guide/configuration-environment-overrides.adoc
+++ b/docs/modules/hdfs/pages/usage-guide/configuration-environment-overrides.adoc
@@ -7,7 +7,7 @@ IMPORTANT: Overriding certain properties can lead to faulty clusters. In general
 
 == Configuration Properties
 
-For a role or role group, at the same level of `config`, you can specify `configOverrides` for the the following files:
+For a role or role group, at the same level of `config`, you can specify `configOverrides` for the following files:
 
 - `hdfs-site.xml`
 - `core-site.xml`

--- a/docs/modules/hdfs/pages/usage-guide/configuration-environment-overrides.adoc
+++ b/docs/modules/hdfs/pages/usage-guide/configuration-environment-overrides.adoc
@@ -11,6 +11,9 @@ For a role or role group, at the same level of `config`, you can specify `config
 
 - `hdfs-site.xml`
 - `core-site.xml`
+- `hadoop-policy.xml`
+- `ssl-server.xml`
+- `ssl-client.xml`
 - `security.properties`
 
 

--- a/rust/crd/src/constants.rs
+++ b/rust/crd/src/constants.rs
@@ -16,6 +16,7 @@ pub const HADOOP_POLICY_XML: &str = "hadoop-policy.xml";
 pub const SSL_SERVER_XML: &str = "ssl-server.xml";
 pub const SSL_CLIENT_XML: &str = "ssl-client.xml";
 pub const LOG4J_PROPERTIES: &str = "log4j.properties";
+pub const JVM_SECURITY_PROPERTIES_FILE: &str = "security.properties";
 
 pub const SERVICE_PORT_NAME_RPC: &str = "rpc";
 pub const SERVICE_PORT_NAME_IPC: &str = "ipc";

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -616,6 +616,7 @@ impl HdfsCluster {
             PropertyNameKind::File(HADOOP_POLICY_XML.to_string()),
             PropertyNameKind::File(SSL_SERVER_XML.to_string()),
             PropertyNameKind::File(SSL_CLIENT_XML.to_string()),
+            PropertyNameKind::File(JVM_SECURITY_PROPERTIES_FILE.to_string()),
             PropertyNameKind::Env,
         ];
 


### PR DESCRIPTION
# Description
 
CI: https://ci.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/hdfs-operator-it-custom/96/

Use JVM defaults explicitly.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [x] Proper release label has been added
```
