### PR TITLE
fix: Don't default roleGroup replicas to zero when not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,16 @@ All notable changes to this project will be documented in this file.
 - Let secret-operator handle certificate conversion ([#392]).
 - `operator-rs` `0.44.0` -> `0.51.1` ([#381], [#394]).
 
+### Fixed
+
+- Don't default roleGroup replicas to zero when not specified ([#402]).
+
 [#378]: https://github.com/stackabletech/hdfs-operator/pull/378
 [#381]: https://github.com/stackabletech/hdfs-operator/pull/381
 [#384]: https://github.com/stackabletech/hdfs-operator/pull/384
 [#392]: https://github.com/stackabletech/hdfs-operator/pull/392
 [#394]: https://github.com/stackabletech/hdfs-operator/pull/394
+[#402]: https://github.com/stackabletech/hdfs-operator/pull/402
 
 ## [23.7.0] - 2023-07-14
 

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -377,23 +377,17 @@ impl HdfsRole {
     }
 
     /// Return replicas for a certain rolegroup.
-    pub fn role_group_replicas(&self, hdfs: &HdfsCluster, role_group: &str) -> i32 {
+    pub fn role_group_replicas(&self, hdfs: &HdfsCluster, role_group: &str) -> Option<u16> {
         match self {
             HdfsRole::NameNode => hdfs
                 .namenode_rolegroup(role_group)
-                .and_then(|rg| rg.replicas)
-                .unwrap_or_default()
-                .into(),
+                .and_then(|rg| rg.replicas),
             HdfsRole::DataNode => hdfs
                 .datanode_rolegroup(role_group)
-                .and_then(|rg| rg.replicas)
-                .unwrap_or_default()
-                .into(),
+                .and_then(|rg| rg.replicas),
             HdfsRole::JournalNode => hdfs
                 .journalnode_rolegroup(role_group)
-                .and_then(|rg| rg.replicas)
-                .unwrap_or_default()
-                .into(),
+                .and_then(|rg| rg.replicas),
         }
     }
 

--- a/rust/operator/src/hdfs_controller.rs
+++ b/rust/operator/src/hdfs_controller.rs
@@ -694,7 +694,9 @@ fn rolegroup_statefulset(
             .build(),
         spec: Some(StatefulSetSpec {
             pod_management_policy: Some("OrderedReady".to_string()),
-            replicas: Some(role.role_group_replicas(hdfs, &rolegroup_ref.role_group)),
+            replicas: role
+                .role_group_replicas(hdfs, &rolegroup_ref.role_group)
+                .map(i32::from),
             selector: LabelSelector {
                 match_labels: Some(role_group_selector_labels(
                     hdfs,


### PR DESCRIPTION
# Description

Fixes https://github.com/stackabletech/hdfs-operator/issues/398
Part of https://github.com/stackabletech/issues/issues/435

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [x] Proper release label has been added
```
