### PR TITLE
switch order of zkfc and vector container in kuttl smoke test

### DIFF
--- a/tests/templates/kuttl/smoke/30-assert.yaml.j2
+++ b/tests/templates/kuttl/smoke/30-assert.yaml.j2
@@ -19,10 +19,10 @@ spec:
             limits:
               cpu: "1" # From defaults
               memory: 1Gi
-        - name: zkfc
 {% if lookup('env', 'VECTOR_AGGREGATOR') %}
         - name: vector
 {% endif %}
+        - name: zkfc
 status:
   readyReplicas: 2
   replicas: 2


### PR DESCRIPTION
# Description

Attempt to fix the smoke tests (somehow the order of vector and zkfc was changed and therefore the asserts fail...)

Want to run a custom test with this.

Probably due to https://github.com/stackabletech/ci/pull/75/files

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
