### PR TITLE
fix: Remove field autoFormatFs, which was never read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Don't default roleGroup replicas to zero when not specified ([#402]).
+- [BREAKING] Removed field `autoFormatFs`, which was never read ([#XXX]).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Don't default roleGroup replicas to zero when not specified ([#402]).
-- [BREAKING] Removed field `autoFormatFs`, which was never read ([#XXX]).
+- [BREAKING] Removed field `autoFormatFs`, which was never read ([#422]).
 
 ### Removed
 
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 [#405]: https://github.com/stackabletech/hdfs-operator/pull/405
 [#407]: https://github.com/stackabletech/hdfs-operator/pull/407
 [#409]: https://github.com/stackabletech/hdfs-operator/pull/409
+[#422]: https://github.com/stackabletech/hdfs-operator/pull/422
 
 ## [23.7.0] - 2023-07-14
 

--- a/deploy/helm/hdfs-operator/crds/crds.yaml
+++ b/deploy/helm/hdfs-operator/crds/crds.yaml
@@ -46,9 +46,6 @@ spec:
                       required:
                         - kerberos
                       type: object
-                    autoFormatFs:
-                      nullable: true
-                      type: boolean
                     dfsReplication:
                       default: 3
                       format: uint8

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -95,8 +95,6 @@ pub struct HdfsClusterSpec {
 #[derive(Clone, Debug, Deserialize, Eq, Hash, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HdfsClusterConfig {
-    // FIXME: This attribute does not seem to be read anywhere.
-    pub auto_format_fs: Option<bool>,
     #[serde(default = "default_dfs_replication_factor")]
     pub dfs_replication: u8,
     /// Name of the Vector aggregator discovery ConfigMap.


### PR DESCRIPTION
# Description

Fixes https://github.com/stackabletech/hdfs-operator/issues/399
There are no usages: https://github.com/search?q=org%3Astackabletech%20autoFormatFs&type=code


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [x] Proper release label has been added
```
