### PR TITLE
Adapt the log levels in the logging tests to avoid false positives

### DIFF
--- a/tests/templates/kuttl/logging/03-install-hdfs-automatic-log.yaml.j2
+++ b/tests/templates/kuttl/logging/03-install-hdfs-automatic-log.yaml.j2
@@ -86,10 +86,13 @@ spec:
                 console:
                   level: INFO
                 file:
-                  level: INFO
+                  # Set the log level to DEBUG because if the NameNodes
+                  # are already ready then nothing is logged at the INFO
+                  # level.
+                  level: DEBUG
                 loggers:
                   ROOT:
-                    level: INFO
+                    level: DEBUG
   journalNodes:
     roleGroups:
       default:

--- a/tests/templates/kuttl/logging/04-install-hdfs-custom-log.yaml.j2
+++ b/tests/templates/kuttl/logging/04-install-hdfs-custom-log.yaml.j2
@@ -49,7 +49,9 @@ metadata:
   name: hdfs-wait-for-namenodes-log-config
 data:
   wait-for-namenodes.log4j.properties: |
-    log4j.rootLogger=INFO, FILE
+    # Set the log level to DEBUG because if the NameNodes are already
+    # ready then nothing is logged at the INFO level.
+    log4j.rootLogger=DEBUG, FILE
     log4j.appender.FILE=org.apache.log4j.FileAppender
     log4j.appender.FILE.File=/stackable/log/wait-for-namenodes/wait-for-namenodes.log4j.xml
     log4j.appender.FILE.layout=org.apache.log4j.xml.XMLLayout


### PR DESCRIPTION
# Description

Set the log levels in the logging tests of the wait-for-namenodes containers to DEBUG so that logs are generated even if the NameNodes are already ready.

For instance, the following event is logged, regardless of whether the NameNodes are ready or not:

```xml
<log4j:event logger="org.apache.hadoop.ipc.Client" timestamp="1704705605632" level="DEBUG" thread="main">
<log4j:message><![CDATA[The ping interval is 60000 ms.]]></log4j:message>
</log4j:event>
```

The console contains only the logs of the shell script. Therefore it is not necessary and useful to change the console log level.

Fixes #443

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
