### PR TITLE
Fix whitespace control in README generation

### DIFF
--- a/.readme/README.md.j2
+++ b/.readme/README.md.j2
@@ -3,11 +3,22 @@
 {%- set operator_docs_slug="hdfs" -%}
 {%- set related_reading_links=[] -%}
 
-{% include "partials/borrowed/header.md.j2" %}
-{% include "partials/borrowed/links.md.j2" %}
+{% filter trim %}
+  {%- include "partials/borrowed/header.md.j2" -%}
+{% endfilter %}
 
-{% include "partials/main.md.j2" %}
+{% filter trim %}
+  {%- include "partials/borrowed/links.md.j2" -%}
+{% endfilter %}
 
-{% include "partials/borrowed/footer.md.j2" %}
+{% filter trim %}
+  {%- include "partials/main.md.j2" -%}
+{% endfilter %}
 
-{% include "partials/borrowed/related_reading.md.j2" %}
+{% filter trim %}
+  {%- include "partials/borrowed/footer.md.j2" -%}
+{% endfilter %}
+
+{% filter trim %}
+  {%- include "partials/borrowed/related_reading.md.j2" -%}
+{% endfilter %}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["rust/crd", "rust/operator-binary"]
+resolver = "2"
 
 [workspace.package]
 version = "0.0.0-dev"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ The documentation for all Stackable products can be found at [docs.stackable.tec
 
 If you have a question about the Stackable Data Platform contact us via our [homepage](https://stackable.tech/) or ask a public questions in our [Discussions forum](https://github.com/orgs/stackabletech/discussions).
 
-
 ## About The Stackable Data Platform
 
 This operator is written and maintained by [Stackable](https://stackable.tech) and it is part of a larger data platform.


### PR DESCRIPTION
# Description

Fix whitespace control in README generation
So far we would include files with all their whitespace which can lead to markdownlint errors and inconsistencies. Now we trim everything we include.

This also switches to resolver v2 for the workspace because the render-readme step would warn about it.

Part of https://github.com/stackabletech/issues/issues/492