### PR TITLE
docs: Fix stackablectl parameters

### DIFF
--- a/docs/modules/hdfs/pages/usage-guide/security.adoc
+++ b/docs/modules/hdfs/pages/usage-guide/security.adoc
@@ -34,7 +34,7 @@ The `tlsSecretClass` is needed to request TLS certificates, used e.g. for the We
 
 
 === 4. Verify that Kerberos is used
-Use `stackablectl services list --all-namespaces` to get the endpoints where the HDFS namenodes are reachable.
+Use `stackablectl stacklet list` to get the endpoints where the HDFS namenodes are reachable.
 Open the link (note that the namenode is now using https).
 You should see a Web UI similar to the following:
 


### PR DESCRIPTION
# Description

Fix stackablectl parameters

stackablectl 23.11 uses the parameter `stacklet` instead of `services` and lists the stacklets of all namespaces by default.