### PR TITLE
Remove `MergedConfig`

### DIFF
--- a/deploy/helm/hdfs-operator/crds/crds.yaml
+++ b/deploy/helm/hdfs-operator/crds/crds.yaml
@@ -107,6 +107,7 @@ spec:
                       type: object
                     config:
                       default: {}
+                      description: Configuration options that are available for all roles.
                       properties:
                         affinity:
                           default:
@@ -3614,6 +3615,7 @@ spec:
                             type: object
                           config:
                             default: {}
+                            description: Configuration options that are available for all roles.
                             properties:
                               affinity:
                                 default:
@@ -7179,6 +7181,7 @@ spec:
                       type: object
                     config:
                       default: {}
+                      description: Configuration options that are available for all roles.
                       properties:
                         affinity:
                           default:
@@ -10677,6 +10680,7 @@ spec:
                             type: object
                           config:
                             default: {}
+                            description: Configuration options that are available for all roles.
                             properties:
                               affinity:
                                 default:
@@ -14187,6 +14191,7 @@ spec:
                       type: object
                     config:
                       default: {}
+                      description: Configuration options that are available for all roles.
                       properties:
                         affinity:
                           default:
@@ -17685,6 +17690,7 @@ spec:
                             type: object
                           config:
                             default: {}
+                            description: Configuration options that are available for all roles.
                             properties:
                               affinity:
                                 default:

--- a/rust/crd/src/affinity.rs
+++ b/rust/crd/src/affinity.rs
@@ -75,8 +75,8 @@ spec:
         let merged_config = role.merged_config(&hdfs, "default").unwrap();
 
         assert_eq!(
-            merged_config.affinity(),
-            &StackableAffinity {
+            merged_config.affinity,
+            StackableAffinity {
                 pod_affinity: Some(PodAffinity {
                     preferred_during_scheduling_ignored_during_execution: Some(vec![
                         WeightedPodAffinityTerm {
@@ -171,8 +171,8 @@ spec:
         let merged_config = HdfsRole::DataNode.merged_config(&hdfs, "default").unwrap();
 
         assert_eq!(
-            merged_config.affinity(),
-            &StackableAffinity {
+            merged_config.affinity,
+            StackableAffinity {
                 pod_affinity: Some(PodAffinity {
                     preferred_during_scheduling_ignored_during_execution: Some(vec![
                         WeightedPodAffinityTerm {

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -1167,7 +1167,7 @@ pub struct JournalNodeConfig {
     pub resources: Resources<HdfsStorageConfig, NoRuntimeLimits>,
     #[fragment_attrs(serde(default))]
     pub logging: Logging<JournalNodeContainer>,
-    #[fragment_attrs(serde(default))]
+    #[fragment_attrs(serde(flatten))]
     pub common: CommonNodeConfig,
 }
 

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -1,4 +1,8 @@
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt::Display,
+    ops::Deref,
+};
 
 use product_config::types::PropertyNameKind;
 use serde::{Deserialize, Serialize};
@@ -191,43 +195,80 @@ pub struct CommonNodeConfig {
     pub graceful_shutdown_timeout: Option<Duration>,
 }
 
-/// This is a shared trait for all role/role-group config structs to avoid duplication
-/// when extracting role specific configuration structs like resources or logging.
-pub trait MergedConfig {
-    fn name_node_resources(&self) -> Option<Resources<HdfsStorageConfig, NoRuntimeLimits>> {
-        None
+#[derive(Debug)]
+pub enum AnyNodeConfig {
+    NameNode(NameNodeConfig),
+    DataNode(DataNodeConfig),
+    JournalNode(JournalNodeConfig),
+}
+
+impl Deref for AnyNodeConfig {
+    type Target = CommonNodeConfig;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            AnyNodeConfig::NameNode(node) => &node.common,
+            AnyNodeConfig::DataNode(node) => &node.common,
+            AnyNodeConfig::JournalNode(node) => &node.common,
+        }
     }
-    fn journal_node_resources(&self) -> Option<Resources<HdfsStorageConfig, NoRuntimeLimits>> {
-        None
+}
+
+impl AnyNodeConfig {
+    pub fn as_namenode(&self) -> Option<&NameNodeConfig> {
+        if let Self::NameNode(node) = self {
+            Some(node)
+        } else {
+            None
+        }
     }
-    fn data_node_resources(
+    pub fn as_datanode(&self) -> Option<&DataNodeConfig> {
+        if let Self::DataNode(node) = self {
+            Some(node)
+        } else {
+            None
+        }
+    }
+    pub fn as_journalnode(&self) -> Option<&JournalNodeConfig> {
+        if let Self::JournalNode(node) = self {
+            Some(node)
+        } else {
+            None
+        }
+    }
+
+    // Logging config is distinct between each variant, due to the different enum types
+    fn common_logging(
         &self,
-    ) -> Option<Resources<DataNodeStorageConfigInnerType, NoRuntimeLimits>> {
-        None
+        namenode_container: NameNodeContainer,
+        datanode_container: DataNodeContainer,
+        journalnode_container: JournalNodeContainer,
+    ) -> ContainerLogConfig {
+        match self {
+            AnyNodeConfig::NameNode(node) => node.logging.for_container(&namenode_container),
+            AnyNodeConfig::DataNode(node) => node.logging.for_container(&datanode_container),
+            AnyNodeConfig::JournalNode(node) => node.logging.for_container(&journalnode_container),
+        }
     }
-    fn affinity(&self) -> &StackableAffinity;
-    fn graceful_shutdown_timeout(&self) -> Option<&Duration>;
-    /// Main container shared by all roles
-    fn hdfs_logging(&self) -> ContainerLogConfig;
-    /// Vector container shared by all roles
-    fn vector_logging(&self) -> ContainerLogConfig;
-    /// Helper method to access if vector container should be deployed
-    fn vector_logging_enabled(&self) -> bool;
-    /// Namenode side container (ZooKeeperFailOverController)
-    fn zkfc_logging(&self) -> Option<ContainerLogConfig> {
-        None
+    pub fn hdfs_logging(&self) -> ContainerLogConfig {
+        self.common_logging(
+            NameNodeContainer::Hdfs,
+            DataNodeContainer::Hdfs,
+            JournalNodeContainer::Hdfs,
+        )
     }
-    /// Namenode init container to format namenode
-    fn format_namenodes_logging(&self) -> Option<ContainerLogConfig> {
-        None
+    pub fn vector_logging(&self) -> ContainerLogConfig {
+        self.common_logging(
+            NameNodeContainer::Vector,
+            DataNodeContainer::Vector,
+            JournalNodeContainer::Vector,
+        )
     }
-    /// Namenode init container to format zookeeper
-    fn format_zookeeper_logging(&self) -> Option<ContainerLogConfig> {
-        None
-    }
-    /// Datanode init container to wait for namenodes to become ready
-    fn wait_for_namenodes(&self) -> Option<ContainerLogConfig> {
-        None
+    pub fn vector_logging_enabled(&self) -> bool {
+        match self {
+            AnyNodeConfig::NameNode(node) => node.logging.enable_vector_agent,
+            AnyNodeConfig::DataNode(node) => node.logging.enable_vector_agent,
+            AnyNodeConfig::JournalNode(node) => node.logging.enable_vector_agent,
+        }
     }
 }
 
@@ -287,7 +328,7 @@ impl HdfsRole {
         &self,
         hdfs: &HdfsCluster,
         role_group: &str,
-    ) -> Result<Box<dyn MergedConfig + Send + 'static>, Error> {
+    ) -> Result<AnyNodeConfig, Error> {
         match self {
             HdfsRole::NameNode => {
                 let default_config = NameNodeConfigFragment::default_config(&hdfs.name_any(), self);
@@ -326,7 +367,7 @@ impl HdfsRole {
 
                 role_config.merge(&default_config);
                 role_group_config.merge(&role_config);
-                Ok(Box::new(
+                Ok(AnyNodeConfig::NameNode(
                     fragment::validate::<NameNodeConfig>(role_group_config)
                         .context(FragmentValidationFailureSnafu)?,
                 ))
@@ -368,7 +409,7 @@ impl HdfsRole {
 
                 role_config.merge(&default_config);
                 role_group_config.merge(&role_config);
-                Ok(Box::new(
+                Ok(AnyNodeConfig::DataNode(
                     fragment::validate::<DataNodeConfig>(role_group_config)
                         .context(FragmentValidationFailureSnafu)?,
                 ))
@@ -411,7 +452,7 @@ impl HdfsRole {
 
                 role_config.merge(&default_config);
                 role_group_config.merge(&role_config);
-                Ok(Box::new(
+                Ok(AnyNodeConfig::JournalNode(
                     fragment::validate::<JournalNodeConfig>(role_group_config)
                         .context(FragmentValidationFailureSnafu)?,
                 ))
@@ -908,61 +949,6 @@ pub struct NameNodeConfig {
     pub common: CommonNodeConfig,
 }
 
-impl MergedConfig for NameNodeConfig {
-    fn name_node_resources(&self) -> Option<Resources<HdfsStorageConfig, NoRuntimeLimits>> {
-        Some(self.resources.clone())
-    }
-
-    fn affinity(&self) -> &StackableAffinity {
-        &self.common.affinity
-    }
-
-    fn graceful_shutdown_timeout(&self) -> Option<&Duration> {
-        self.common.graceful_shutdown_timeout.as_ref()
-    }
-
-    fn hdfs_logging(&self) -> ContainerLogConfig {
-        self.logging
-            .containers
-            .get(&NameNodeContainer::Hdfs)
-            .cloned()
-            .unwrap_or_default()
-    }
-
-    fn vector_logging(&self) -> ContainerLogConfig {
-        self.logging
-            .containers
-            .get(&NameNodeContainer::Vector)
-            .cloned()
-            .unwrap_or_default()
-    }
-
-    fn vector_logging_enabled(&self) -> bool {
-        self.logging.enable_vector_agent
-    }
-
-    fn zkfc_logging(&self) -> Option<ContainerLogConfig> {
-        self.logging
-            .containers
-            .get(&NameNodeContainer::Zkfc)
-            .cloned()
-    }
-
-    fn format_namenodes_logging(&self) -> Option<ContainerLogConfig> {
-        self.logging
-            .containers
-            .get(&NameNodeContainer::FormatNameNodes)
-            .cloned()
-    }
-
-    fn format_zookeeper_logging(&self) -> Option<ContainerLogConfig> {
-        self.logging
-            .containers
-            .get(&NameNodeContainer::FormatZooKeeper)
-            .cloned()
-    }
-}
-
 impl NameNodeConfigFragment {
     pub fn default_config(cluster_name: &str, role: &HdfsRole) -> Self {
         Self {
@@ -1073,49 +1059,6 @@ pub struct DataNodeConfig {
     pub logging: Logging<DataNodeContainer>,
     #[fragment_attrs(serde(flatten))]
     pub common: CommonNodeConfig,
-}
-
-impl MergedConfig for DataNodeConfig {
-    fn data_node_resources(
-        &self,
-    ) -> Option<Resources<DataNodeStorageConfigInnerType, NoRuntimeLimits>> {
-        Some(self.resources.clone())
-    }
-
-    fn affinity(&self) -> &StackableAffinity {
-        &self.common.affinity
-    }
-
-    fn graceful_shutdown_timeout(&self) -> Option<&Duration> {
-        self.common.graceful_shutdown_timeout.as_ref()
-    }
-
-    fn hdfs_logging(&self) -> ContainerLogConfig {
-        self.logging
-            .containers
-            .get(&DataNodeContainer::Hdfs)
-            .cloned()
-            .unwrap_or_default()
-    }
-
-    fn vector_logging(&self) -> ContainerLogConfig {
-        self.logging
-            .containers
-            .get(&DataNodeContainer::Vector)
-            .cloned()
-            .unwrap_or_default()
-    }
-
-    fn vector_logging_enabled(&self) -> bool {
-        self.logging.enable_vector_agent
-    }
-
-    fn wait_for_namenodes(&self) -> Option<ContainerLogConfig> {
-        self.logging
-            .containers
-            .get(&DataNodeContainer::WaitForNameNodes)
-            .cloned()
-    }
 }
 
 impl DataNodeConfigFragment {
@@ -1233,40 +1176,6 @@ pub struct JournalNodeConfig {
     pub common: CommonNodeConfig,
 }
 
-impl MergedConfig for JournalNodeConfig {
-    fn journal_node_resources(&self) -> Option<Resources<HdfsStorageConfig, NoRuntimeLimits>> {
-        Some(self.resources.clone())
-    }
-
-    fn affinity(&self) -> &StackableAffinity {
-        &self.common.affinity
-    }
-
-    fn graceful_shutdown_timeout(&self) -> Option<&Duration> {
-        self.common.graceful_shutdown_timeout.as_ref()
-    }
-
-    fn hdfs_logging(&self) -> ContainerLogConfig {
-        self.logging
-            .containers
-            .get(&JournalNodeContainer::Hdfs)
-            .cloned()
-            .unwrap_or_default()
-    }
-
-    fn vector_logging(&self) -> ContainerLogConfig {
-        self.logging
-            .containers
-            .get(&JournalNodeContainer::Vector)
-            .cloned()
-            .unwrap_or_default()
-    }
-
-    fn vector_logging_enabled(&self) -> bool {
-        self.logging.enable_vector_agent
-    }
-}
-
 impl JournalNodeConfigFragment {
     pub fn default_config(cluster_name: &str, role: &HdfsRole) -> Self {
         Self {
@@ -1341,6 +1250,22 @@ impl HasStatusCondition for HdfsCluster {
     }
 }
 
+// TODO: upstream?
+pub trait LoggingExt {
+    type Container;
+    fn for_container(&self, container: &Self::Container) -> ContainerLogConfig;
+}
+impl<T> LoggingExt for Logging<T>
+where
+    T: Ord + Clone + Display,
+{
+    type Container = T;
+
+    fn for_container(&self, container: &Self::Container) -> ContainerLogConfig {
+        self.containers.get(container).cloned().unwrap_or_default()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::storage::HdfsStorageType;
@@ -1376,11 +1301,8 @@ spec:
 
         let hdfs: HdfsCluster = serde_yaml::from_str(cr).unwrap();
         let role = HdfsRole::DataNode;
-        let resources = role
-            .merged_config(&hdfs, "default")
-            .unwrap()
-            .data_node_resources()
-            .unwrap();
+        let config = &role.merged_config(&hdfs, "default").unwrap();
+        let resources = &config.as_datanode().unwrap().resources;
         let pvc = resources.storage.get("data").unwrap();
 
         assert_eq!(pvc.count, 1);
@@ -1414,11 +1336,8 @@ spec:
 
         let hdfs: HdfsCluster = serde_yaml::from_str(cr).unwrap();
         let role = HdfsRole::DataNode;
-        let resources = role
-            .merged_config(&hdfs, "default")
-            .unwrap()
-            .data_node_resources()
-            .unwrap();
+        let config = &role.merged_config(&hdfs, "default").unwrap();
+        let resources = &config.as_datanode().unwrap().resources;
         let pvc = resources.storage.get("data").unwrap();
 
         assert_eq!(pvc.count, 1);
@@ -1447,11 +1366,8 @@ spec:
 
         let hdfs: HdfsCluster = serde_yaml::from_str(cr).unwrap();
         let role = HdfsRole::DataNode;
-        let resources = role
-            .merged_config(&hdfs, "default")
-            .unwrap()
-            .data_node_resources()
-            .unwrap();
+        let config = role.merged_config(&hdfs, "default").unwrap();
+        let resources = &config.as_datanode().unwrap().resources;
         let pvc = resources.storage.get("data").unwrap();
 
         assert_eq!(pvc.count, 1);
@@ -1501,11 +1417,8 @@ spec:
 
         let hdfs: HdfsCluster = serde_yaml::from_str(cr).unwrap();
         let role = HdfsRole::DataNode;
-        let resources = role
-            .merged_config(&hdfs, "default")
-            .unwrap()
-            .data_node_resources()
-            .unwrap();
+        let config = &role.merged_config(&hdfs, "default").unwrap();
+        let resources = &config.as_datanode().unwrap().resources;
 
         let pvc = resources.storage.get("data").unwrap();
         assert_eq!(pvc.count, 0);
@@ -1554,8 +1467,10 @@ spec:
         let rr: ResourceRequirements = role
             .merged_config(&hdfs, "default")
             .unwrap()
-            .data_node_resources()
+            .as_datanode()
             .unwrap()
+            .resources
+            .clone()
             .into();
 
         let expected = ResourceRequirements {
@@ -1607,8 +1522,10 @@ spec:
         let rr: ResourceRequirements = role
             .merged_config(&hdfs, "default")
             .unwrap()
-            .data_node_resources()
+            .as_datanode()
             .unwrap()
+            .resources
+            .clone()
             .into();
 
         let expected = ResourceRequirements {

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -174,6 +174,7 @@ impl CurrentlySupportedListenerClasses {
     }
 }
 
+/// Configuration options that are available for all roles.
 #[derive(Clone, Debug, Default, Fragment, JsonSchema, PartialEq)]
 #[fragment_attrs(
     derive(
@@ -196,6 +197,7 @@ pub struct CommonNodeConfig {
     pub graceful_shutdown_timeout: Option<Duration>,
 }
 
+/// Configuration for a rolegroup of an unknown type.
 #[derive(Debug)]
 pub enum AnyNodeConfig {
     NameNode(NameNodeConfig),

--- a/rust/operator-binary/src/container.rs
+++ b/rust/operator-binary/src/container.rs
@@ -26,7 +26,8 @@ use stackable_hdfs_crd::{
         SERVICE_PORT_NAME_IPC, SERVICE_PORT_NAME_RPC, STACKABLE_ROOT_DATA_DIR,
     },
     storage::DataNodeStorageConfig,
-    DataNodeContainer, HdfsCluster, HdfsPodRef, HdfsRole, MergedConfig, NameNodeContainer,
+    AnyNodeConfig, DataNodeContainer, HdfsCluster, HdfsPodRef, HdfsRole, LoggingExt as _,
+    NameNodeContainer,
 };
 use stackable_operator::{
     builder::SecretFormat,
@@ -153,7 +154,7 @@ impl ContainerConfig {
         hdfs: &HdfsCluster,
         role: &HdfsRole,
         resolved_product_image: &ResolvedProductImage,
-        merged_config: &(dyn MergedConfig + Send + 'static),
+        merged_config: &AnyNodeConfig,
         env_overrides: Option<&BTreeMap<String, String>>,
         zk_config_map_name: &str,
         object_name: &str,
@@ -288,27 +289,20 @@ impl ContainerConfig {
         Ok(())
     }
 
-    pub fn volume_claim_templates(
-        role: &HdfsRole,
-        merged_config: &(dyn MergedConfig + Send + 'static),
-    ) -> Option<Vec<PersistentVolumeClaim>> {
-        match role {
-            HdfsRole::NameNode => merged_config.name_node_resources().map(|r| {
-                vec![r.storage.data.build_pvc(
-                    ContainerConfig::DATA_VOLUME_MOUNT_NAME,
-                    Some(vec!["ReadWriteOnce"]),
-                )]
-            }),
-            HdfsRole::JournalNode => merged_config.journal_node_resources().map(|r| {
-                vec![r.storage.data.build_pvc(
-                    ContainerConfig::DATA_VOLUME_MOUNT_NAME,
-                    Some(vec!["ReadWriteOnce"]),
-                )]
-            }),
-            HdfsRole::DataNode => merged_config
-                .data_node_resources()
-                .map(|r| r.storage)
-                .map(|storage| DataNodeStorageConfig { pvcs: storage }.build_pvcs()),
+    pub fn volume_claim_templates(merged_config: &AnyNodeConfig) -> Vec<PersistentVolumeClaim> {
+        match merged_config {
+            AnyNodeConfig::NameNode(node) => vec![node.resources.storage.data.build_pvc(
+                ContainerConfig::DATA_VOLUME_MOUNT_NAME,
+                Some(vec!["ReadWriteOnce"]),
+            )],
+            AnyNodeConfig::JournalNode(node) => vec![node.resources.storage.data.build_pvc(
+                ContainerConfig::DATA_VOLUME_MOUNT_NAME,
+                Some(vec!["ReadWriteOnce"]),
+            )],
+            AnyNodeConfig::DataNode(node) => DataNodeStorageConfig {
+                pvcs: node.resources.storage.clone(),
+            }
+            .build_pvcs(),
         }
     }
 
@@ -324,7 +318,7 @@ impl ContainerConfig {
         resolved_product_image: &ResolvedProductImage,
         zookeeper_config_map_name: &str,
         env_overrides: Option<&BTreeMap<String, String>>,
-        merged_config: &(dyn MergedConfig + Send + 'static),
+        merged_config: &AnyNodeConfig,
     ) -> Result<Container, Error> {
         let mut cb =
             ContainerBuilder::new(self.name()).with_context(|_| InvalidContainerNameSnafu {
@@ -369,7 +363,7 @@ impl ContainerConfig {
         zookeeper_config_map_name: &str,
         env_overrides: Option<&BTreeMap<String, String>>,
         namenode_podrefs: &[HdfsPodRef],
-        merged_config: &(dyn MergedConfig + Send + 'static),
+        merged_config: &AnyNodeConfig,
     ) -> Result<Container, Error> {
         let mut cb = ContainerBuilder::new(self.name())
             .with_context(|_| InvalidContainerNameSnafu { name: self.name() })?;
@@ -428,7 +422,7 @@ impl ContainerConfig {
         &self,
         hdfs: &HdfsCluster,
         role: &HdfsRole,
-        merged_config: &(dyn MergedConfig + Send + 'static),
+        merged_config: &AnyNodeConfig,
         namenode_podrefs: &[HdfsPodRef],
     ) -> Result<Vec<String>, Error> {
         let mut args = String::new();
@@ -464,7 +458,10 @@ wait_for_termination $!
                 ));
             }
             ContainerConfig::Zkfc { .. } => {
-                if let Some(container_config) = merged_config.zkfc_logging() {
+                if let Some(container_config) = merged_config
+                    .as_namenode()
+                    .map(|node| node.logging.for_container(&NameNodeContainer::Zkfc))
+                {
                     args.push_str(
                         &self.copy_log4j_properties_cmd(ZKFC_LOG4J_CONFIG_FILE, container_config),
                     );
@@ -475,7 +472,10 @@ wait_for_termination $!
                 ));
             }
             ContainerConfig::FormatNameNodes { .. } => {
-                if let Some(container_config) = merged_config.format_namenodes_logging() {
+                if let Some(container_config) = merged_config.as_namenode().map(|node| {
+                    node.logging
+                        .for_container(&NameNodeContainer::FormatNameNodes)
+                }) {
                     args.push_str(&self.copy_log4j_properties_cmd(
                         FORMAT_NAMENODES_LOG4J_CONFIG_FILE,
                         container_config,
@@ -532,7 +532,10 @@ wait_for_termination $!
                 ));
             }
             ContainerConfig::FormatZooKeeper { .. } => {
-                if let Some(container_config) = merged_config.format_zookeeper_logging() {
+                if let Some(container_config) = merged_config.as_namenode().map(|node| {
+                    node.logging
+                        .for_container(&NameNodeContainer::FormatZooKeeper)
+                }) {
                     args.push_str(&self.copy_log4j_properties_cmd(
                         FORMAT_ZOOKEEPER_LOG4J_CONFIG_FILE,
                         container_config,
@@ -563,7 +566,10 @@ wait_for_termination $!
                 ));
             }
             ContainerConfig::WaitForNameNodes { .. } => {
-                if let Some(container_config) = merged_config.wait_for_namenodes() {
+                if let Some(container_config) = merged_config.as_datanode().map(|node| {
+                    node.logging
+                        .for_container(&DataNodeContainer::WaitForNameNodes)
+                }) {
                     args.push_str(&self.copy_log4j_properties_cmd(
                         WAIT_FOR_NAMENODES_LOG4J_CONFIG_FILE,
                         container_config,
@@ -706,20 +712,8 @@ wait_for_termination $!
     }
 
     /// Returns the container resources.
-    fn resources(
-        &self,
-        merged_config: &(dyn MergedConfig + Send + 'static),
-    ) -> Option<ResourceRequirements> {
+    fn resources(&self, merged_config: &AnyNodeConfig) -> Option<ResourceRequirements> {
         match self {
-            ContainerConfig::Hdfs { role, .. } => match role {
-                HdfsRole::NameNode => merged_config.name_node_resources().map(|r| r.into()),
-                HdfsRole::DataNode => merged_config.data_node_resources().map(|r| r.into()),
-                HdfsRole::JournalNode => merged_config.journal_node_resources().map(|r| r.into()),
-            },
-            // Namenode init containers
-            ContainerConfig::FormatNameNodes { .. } | ContainerConfig::FormatZooKeeper { .. } => {
-                merged_config.name_node_resources().map(|c| c.into())
-            }
             // Namenode sidecar containers
             ContainerConfig::Zkfc { .. } => Some(
                 ResourceRequirementsBuilder::new()
@@ -729,10 +723,15 @@ wait_for_termination $!
                     .with_memory_limit("512Mi")
                     .build(),
             ),
-            // Datanode init containers
-            ContainerConfig::WaitForNameNodes { .. } => {
-                merged_config.data_node_resources().map(|c| c.into())
-            }
+            // Main container and init containers
+            ContainerConfig::Hdfs { .. }
+            | ContainerConfig::FormatNameNodes { .. }
+            | ContainerConfig::FormatZooKeeper { .. }
+            | ContainerConfig::WaitForNameNodes { .. } => match merged_config {
+                AnyNodeConfig::NameNode(node) => Some(node.resources.clone().into()),
+                AnyNodeConfig::DataNode(node) => Some(node.resources.clone().into()),
+                AnyNodeConfig::JournalNode(node) => Some(node.resources.clone().into()),
+            },
         }
     }
 
@@ -761,11 +760,7 @@ wait_for_termination $!
     }
 
     /// Return the container volumes.
-    fn volumes(
-        &self,
-        merged_config: &(dyn MergedConfig + Send + 'static),
-        object_name: &str,
-    ) -> Vec<Volume> {
+    fn volumes(&self, merged_config: &AnyNodeConfig, object_name: &str) -> Vec<Volume> {
         let mut volumes = vec![];
 
         let container_log_config = match self {
@@ -789,10 +784,21 @@ wait_for_termination $!
 
                 Some(merged_config.hdfs_logging())
             }
-            ContainerConfig::Zkfc { .. } => merged_config.zkfc_logging(),
-            ContainerConfig::FormatNameNodes { .. } => merged_config.format_namenodes_logging(),
-            ContainerConfig::FormatZooKeeper { .. } => merged_config.format_zookeeper_logging(),
-            ContainerConfig::WaitForNameNodes { .. } => merged_config.wait_for_namenodes(),
+            ContainerConfig::Zkfc { .. } => merged_config
+                .as_namenode()
+                .map(|node| node.logging.for_container(&NameNodeContainer::Zkfc)),
+            ContainerConfig::FormatNameNodes { .. } => merged_config.as_namenode().map(|node| {
+                node.logging
+                    .for_container(&NameNodeContainer::FormatNameNodes)
+            }),
+            ContainerConfig::FormatZooKeeper { .. } => merged_config.as_namenode().map(|node| {
+                node.logging
+                    .for_container(&NameNodeContainer::FormatZooKeeper)
+            }),
+            ContainerConfig::WaitForNameNodes { .. } => merged_config.as_datanode().map(|node| {
+                node.logging
+                    .for_container(&DataNodeContainer::WaitForNameNodes)
+            }),
         };
 
         volumes.extend(Self::common_container_volumes(
@@ -806,11 +812,7 @@ wait_for_termination $!
     }
 
     /// Returns the container volume mounts.
-    fn volume_mounts(
-        &self,
-        hdfs: &HdfsCluster,
-        merged_config: &(dyn MergedConfig + Send + 'static),
-    ) -> Vec<VolumeMount> {
+    fn volume_mounts(&self, hdfs: &HdfsCluster, merged_config: &AnyNodeConfig) -> Vec<VolumeMount> {
         let mut volume_mounts = vec![
             VolumeMountBuilder::new(Self::STACKABLE_LOG_VOLUME_MOUNT_NAME, STACKABLE_LOG_DIR)
                 .build(),
@@ -855,10 +857,7 @@ wait_for_termination $!
                     );
                 }
                 HdfsRole::DataNode => {
-                    for pvc in Self::volume_claim_templates(role, merged_config)
-                        .iter()
-                        .flatten()
-                    {
+                    for pvc in Self::volume_claim_templates(merged_config) {
                         let pvc_name = pvc.name_any();
                         volume_mounts.push(VolumeMount {
                             mount_path: format!("{DATANODE_ROOT_DATA_DIR_PREFIX}{pvc_name}"),

--- a/rust/operator-binary/src/container.rs
+++ b/rust/operator-binary/src/container.rs
@@ -438,7 +438,7 @@ impl ContainerConfig {
             ContainerConfig::Hdfs { role, .. } => {
                 args.push_str(&self.copy_log4j_properties_cmd(
                     HDFS_LOG4J_CONFIG_FILE,
-                    merged_config.hdfs_logging(),
+                    &merged_config.hdfs_logging(),
                 ));
 
                 args.push_str(&format!(
@@ -463,7 +463,7 @@ wait_for_termination $!
                     .map(|node| node.logging.for_container(&NameNodeContainer::Zkfc))
                 {
                     args.push_str(
-                        &self.copy_log4j_properties_cmd(ZKFC_LOG4J_CONFIG_FILE, container_config),
+                        &self.copy_log4j_properties_cmd(ZKFC_LOG4J_CONFIG_FILE, &container_config),
                     );
                 }
                 args.push_str(&format!(
@@ -478,7 +478,7 @@ wait_for_termination $!
                 }) {
                     args.push_str(&self.copy_log4j_properties_cmd(
                         FORMAT_NAMENODES_LOG4J_CONFIG_FILE,
-                        container_config,
+                        &container_config,
                     ));
                 }
                 // First step we check for active namenodes. This step should return an active namenode
@@ -538,7 +538,7 @@ wait_for_termination $!
                 }) {
                     args.push_str(&self.copy_log4j_properties_cmd(
                         FORMAT_ZOOKEEPER_LOG4J_CONFIG_FILE,
-                        container_config,
+                        &container_config,
                     ));
                 }
                 args.push_str(&formatdoc!(
@@ -572,7 +572,7 @@ wait_for_termination $!
                 }) {
                     args.push_str(&self.copy_log4j_properties_cmd(
                         WAIT_FOR_NAMENODES_LOG4J_CONFIG_FILE,
-                        container_config,
+                        &container_config,
                     ));
                 }
                 if hdfs.has_kerberos_enabled() {
@@ -802,7 +802,7 @@ wait_for_termination $!
         };
 
         volumes.extend(Self::common_container_volumes(
-            container_log_config,
+            container_log_config.as_deref(),
             object_name,
             self.volume_mount_dirs().config_mount_name(),
             self.volume_mount_dirs().log_mount_name(),
@@ -899,7 +899,7 @@ wait_for_termination $!
     fn copy_log4j_properties_cmd(
         &self,
         log4j_config_file: &str,
-        container_log_config: ContainerLogConfig,
+        container_log_config: &ContainerLogConfig,
     ) -> String {
         let source_log4j_properties_dir = if let ContainerLogConfig {
             choice: Some(ContainerLogConfigChoice::Custom(_)),
@@ -1044,7 +1044,7 @@ wait_for_termination $!
 
     /// Common container specific log and config volumes
     fn common_container_volumes(
-        container_log_config: Option<ContainerLogConfig>,
+        container_log_config: Option<&ContainerLogConfig>,
         object_name: &str,
         config_volume_name: &str,
         log_volume_name: &str,
@@ -1069,7 +1069,7 @@ wait_for_termination $!
                 volumes.push(
                     VolumeBuilder::new(log_volume_name)
                         .config_map(ConfigMapVolumeSource {
-                            name: Some(config_map),
+                            name: Some(config_map.clone()),
                             ..ConfigMapVolumeSource::default()
                         })
                         .build(),

--- a/rust/operator-binary/src/operations/graceful_shutdown.rs
+++ b/rust/operator-binary/src/operations/graceful_shutdown.rs
@@ -1,5 +1,5 @@
 use snafu::{ResultExt, Snafu};
-use stackable_hdfs_crd::MergedConfig;
+use stackable_hdfs_crd::CommonNodeConfig;
 use stackable_operator::builder::PodBuilder;
 
 #[derive(Debug, Snafu)]
@@ -11,14 +11,14 @@ pub enum Error {
 }
 
 pub fn add_graceful_shutdown_config(
-    merged_config: &(dyn MergedConfig + Send + 'static),
+    merged_config: &CommonNodeConfig,
     pod_builder: &mut PodBuilder,
 ) -> Result<(), Error> {
     // This must be always set by the merge mechanism, as we provide a default value,
     // users can not disable graceful shutdown.
-    if let Some(graceful_shutdown_timeout) = merged_config.graceful_shutdown_timeout() {
+    if let Some(graceful_shutdown_timeout) = merged_config.graceful_shutdown_timeout {
         pod_builder
-            .termination_grace_period(graceful_shutdown_timeout)
+            .termination_grace_period(&graceful_shutdown_timeout)
             .context(SetTerminationGracePeriodSnafu)?;
     }
 

--- a/rust/operator-binary/src/product_logging.rs
+++ b/rust/operator-binary/src/product_logging.rs
@@ -1,5 +1,9 @@
+use std::fmt::Display;
+
 use snafu::{OptionExt, ResultExt, Snafu};
-use stackable_hdfs_crd::{DataNodeContainer, HdfsCluster, MergedConfig, NameNodeContainer};
+use stackable_hdfs_crd::{
+    AnyNodeConfig, DataNodeContainer, HdfsCluster, LoggingExt, NameNodeContainer,
+};
 use stackable_operator::{
     builder::ConfigMapBuilder,
     client::Client,
@@ -114,115 +118,87 @@ pub async fn resolve_vector_aggregator_address(
 pub fn extend_role_group_config_map(
     rolegroup: &RoleGroupRef<HdfsCluster>,
     vector_aggregator_address: Option<&str>,
-    merged_config: &(dyn MergedConfig + Send + 'static),
+    merged_config: &AnyNodeConfig,
     cm_builder: &mut ConfigMapBuilder,
 ) -> Result<()> {
-    if let ContainerLogConfig {
-        choice: Some(ContainerLogConfigChoice::Automatic(log_config)),
-    } = merged_config.hdfs_logging()
-    {
-        cm_builder.add_data(
-            HDFS_LOG4J_CONFIG_FILE,
-            product_logging::framework::create_log4j_config(
-                &format!("{STACKABLE_LOG_DIR}/hdfs"),
-                HDFS_LOG_FILE,
-                MAX_HDFS_LOG_FILE_SIZE
-                    .scale_to(BinaryMultiple::Mebi)
-                    .floor()
-                    .value as u32,
-                CONSOLE_CONVERSION_PATTERN,
-                &log_config,
-            ),
-        );
-    }
-
-    if let Some(ContainerLogConfig {
-        choice: Some(ContainerLogConfigChoice::Automatic(log_config)),
-    }) = merged_config.zkfc_logging()
-    {
-        cm_builder.add_data(
-            ZKFC_LOG4J_CONFIG_FILE,
-            product_logging::framework::create_log4j_config(
-                &format!(
-                    "{STACKABLE_LOG_DIR}/{container_name}",
-                    container_name = NameNodeContainer::Zkfc
+    fn add_log4j_config_if_automatic(
+        cm_builder: &mut ConfigMapBuilder,
+        log_config: Option<ContainerLogConfig>,
+        log_config_file: &str,
+        container_name: impl Display,
+        log_file: &str,
+        max_log_file_size: MemoryQuantity,
+    ) {
+        if let Some(ContainerLogConfig {
+            choice: Some(ContainerLogConfigChoice::Automatic(log_config)),
+        }) = log_config
+        {
+            cm_builder.add_data(
+                log_config_file,
+                product_logging::framework::create_log4j_config(
+                    &format!("{STACKABLE_LOG_DIR}/{container_name}"),
+                    log_file,
+                    max_log_file_size
+                        .scale_to(BinaryMultiple::Mebi)
+                        .floor()
+                        .value as u32,
+                    CONSOLE_CONVERSION_PATTERN,
+                    &log_config,
                 ),
-                ZKFC_LOG_FILE,
-                MAX_ZKFC_LOG_FILE_SIZE
-                    .scale_to(BinaryMultiple::Mebi)
-                    .floor()
-                    .value as u32,
-                CONSOLE_CONVERSION_PATTERN,
-                &log_config,
-            ),
-        );
+            );
+        }
     }
-
-    if let Some(ContainerLogConfig {
-        choice: Some(ContainerLogConfigChoice::Automatic(log_config)),
-    }) = merged_config.format_namenodes_logging()
-    {
-        cm_builder.add_data(
-            FORMAT_NAMENODES_LOG4J_CONFIG_FILE,
-            product_logging::framework::create_log4j_config(
-                &format!(
-                    "{STACKABLE_LOG_DIR}/{container_name}",
-                    container_name = NameNodeContainer::FormatNameNodes
-                ),
-                FORMAT_NAMENODES_LOG_FILE,
-                MAX_FORMAT_NAMENODE_LOG_FILE_SIZE
-                    .scale_to(BinaryMultiple::Mebi)
-                    .floor()
-                    .value as u32,
-                CONSOLE_CONVERSION_PATTERN,
-                &log_config,
-            ),
-        );
-    }
-
-    if let Some(ContainerLogConfig {
-        choice: Some(ContainerLogConfigChoice::Automatic(log_config)),
-    }) = merged_config.format_zookeeper_logging()
-    {
-        cm_builder.add_data(
-            FORMAT_ZOOKEEPER_LOG4J_CONFIG_FILE,
-            product_logging::framework::create_log4j_config(
-                &format!(
-                    "{STACKABLE_LOG_DIR}/{container_name}",
-                    container_name = NameNodeContainer::FormatZooKeeper
-                ),
-                FORMAT_ZOOKEEPER_LOG_FILE,
-                MAX_FORMAT_ZOOKEEPER_LOG_FILE_SIZE
-                    .scale_to(BinaryMultiple::Mebi)
-                    .floor()
-                    .value as u32,
-                CONSOLE_CONVERSION_PATTERN,
-                &log_config,
-            ),
-        );
-    }
-
-    if let Some(ContainerLogConfig {
-        choice: Some(ContainerLogConfigChoice::Automatic(log_config)),
-    }) = merged_config.wait_for_namenodes()
-    {
-        cm_builder.add_data(
-            WAIT_FOR_NAMENODES_LOG4J_CONFIG_FILE,
-            product_logging::framework::create_log4j_config(
-                &format!(
-                    "{STACKABLE_LOG_DIR}/{container_name}",
-                    container_name = DataNodeContainer::WaitForNameNodes
-                ),
-                WAIT_FOR_NAMENODES_LOG_FILE,
-                MAX_WAIT_NAMENODES_LOG_FILE_SIZE
-                    .scale_to(BinaryMultiple::Mebi)
-                    .floor()
-                    .value as u32,
-                CONSOLE_CONVERSION_PATTERN,
-                &log_config,
-            ),
-        );
-    }
+    add_log4j_config_if_automatic(
+        cm_builder,
+        Some(merged_config.hdfs_logging()),
+        HDFS_LOG4J_CONFIG_FILE,
+        "hdfs",
+        HDFS_LOG_FILE,
+        MAX_HDFS_LOG_FILE_SIZE,
+    );
+    add_log4j_config_if_automatic(
+        cm_builder,
+        merged_config
+            .as_namenode()
+            .map(|nn| nn.logging.for_container(&NameNodeContainer::Zkfc)),
+        ZKFC_LOG4J_CONFIG_FILE,
+        &NameNodeContainer::Zkfc,
+        ZKFC_LOG_FILE,
+        MAX_ZKFC_LOG_FILE_SIZE,
+    );
+    add_log4j_config_if_automatic(
+        cm_builder,
+        merged_config.as_namenode().map(|nn| {
+            nn.logging
+                .for_container(&NameNodeContainer::FormatNameNodes)
+        }),
+        FORMAT_NAMENODES_LOG4J_CONFIG_FILE,
+        &NameNodeContainer::FormatNameNodes,
+        FORMAT_NAMENODES_LOG_FILE,
+        MAX_FORMAT_NAMENODE_LOG_FILE_SIZE,
+    );
+    add_log4j_config_if_automatic(
+        cm_builder,
+        merged_config.as_namenode().map(|nn| {
+            nn.logging
+                .for_container(&NameNodeContainer::FormatZooKeeper)
+        }),
+        FORMAT_ZOOKEEPER_LOG4J_CONFIG_FILE,
+        &NameNodeContainer::FormatZooKeeper,
+        FORMAT_ZOOKEEPER_LOG_FILE,
+        MAX_FORMAT_ZOOKEEPER_LOG_FILE_SIZE,
+    );
+    add_log4j_config_if_automatic(
+        cm_builder,
+        merged_config.as_datanode().map(|dn| {
+            dn.logging
+                .for_container(&DataNodeContainer::WaitForNameNodes)
+        }),
+        WAIT_FOR_NAMENODES_LOG4J_CONFIG_FILE,
+        &DataNodeContainer::WaitForNameNodes,
+        WAIT_FOR_NAMENODES_LOG_FILE,
+        MAX_WAIT_NAMENODES_LOG_FILE_SIZE,
+    );
 
     let vector_log_config = if let ContainerLogConfig {
         choice: Some(ContainerLogConfigChoice::Automatic(log_config)),


### PR DESCRIPTION
# Description

Fixes #456.

This is intended to solve two things:

1. Having to add every new config field to umpteen places, adding a lot of busywork to every change (and a lot of annoying indirection when trying to chase down the real definition of everything).
2. `MergedConfig` containing the union of all roles' options, making it unclear which fields available when (and the especially comical case where `resources` exists in all variants... but still has a separate accessor method for each).

Instead, this PR delegates actually-common options to the new `struct CommonNodeConfig` and introduces a new `enum AnyNodeConfig` which users can explicitly downcast from to access role-specific options. Common options are accessible immediately because `AnyNodeConfig` derefs to `CommonNodeConfig`.

This PR replaces all uses of `&dyn MergedConfig` with `&AnyNodeConfig` to minimize impact. In the future, it's intended that new code that is only relevant for a single role should use that role's config type directly.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [x] (Integration-)Test cases added
- [x] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/style-guide).
- [ ] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
