### PR TITLE
Change default value for `dfs.ha.nn.not-become-active-in-safemode` to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - `operator-rs` `0.56.1` -> `0.57.0` ([#433]).
-- Change default value of `dfs.ha.nn.not-become-active-in-safemode` from `true` to `false` ([#264]). 
+- Change default value of `dfs.ha.nn.not-become-active-in-safemode` from `true` to `false` ([#264]).
 
 ### Fixed
 
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file.
 
 [#433]: https://github.com/stackabletech/hdfs-operator/pull/433
 [#451]: https://github.com/stackabletech/hdfs-operator/pull/451
-[#433]: https://github.com/stackabletech/hdfs-operator/pull/264
+[#264]: https://github.com/stackabletech/hdfs-operator/pull/264
 
 ## [23.11.0] - 2023-11-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - `operator-rs` `0.56.1` -> `0.57.0` ([#433]).
-- Change default value of `dfs.ha.nn.not-become-active-in-safemode` from `true` to `false` ([#264]).
+- Change default value of `dfs.ha.nn.not-become-active-in-safemode` from `true` to `false` ([#458]).
 
 ### Fixed
 
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file.
 
 [#433]: https://github.com/stackabletech/hdfs-operator/pull/433
 [#451]: https://github.com/stackabletech/hdfs-operator/pull/451
-[#264]: https://github.com/stackabletech/hdfs-operator/pull/264
+[#458]: https://github.com/stackabletech/hdfs-operator/pull/458
 
 ## [23.11.0] - 2023-11-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - `operator-rs` `0.56.1` -> `0.57.0` ([#433]).
+- Change default value of `dfs.ha.nn.not-become-active-in-safemode` from `true` to `false` ([#264]). 
 
 ### Fixed
 
@@ -19,6 +20,7 @@ All notable changes to this project will be documented in this file.
 
 [#433]: https://github.com/stackabletech/hdfs-operator/pull/433
 [#451]: https://github.com/stackabletech/hdfs-operator/pull/451
+[#433]: https://github.com/stackabletech/hdfs-operator/pull/264
 
 ## [23.11.0] - 2023-11-24
 

--- a/rust/operator-binary/src/hdfs_controller.rs
+++ b/rust/operator-binary/src/hdfs_controller.rs
@@ -494,6 +494,15 @@ fn rolegroup_config_map(
                 // IMPORTANT: these folders must be under the volume mount point, otherwise they will not
                 // be formatted by the namenode, or used by the other services.
                 // See also: https://github.com/apache-spark-on-k8s/kubernetes-HDFS/commit/aef9586ecc8551ca0f0a468c3b917d8c38f494a0
+                //
+                // Notes on configuration choices
+                // ===============================
+                // We used to set `dfs.ha.nn.not-become-active-in-safemode` to true here due to
+                // badly worded HDFS documentation:
+                // https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HDFSHighAvailabilityWithNFS.html
+                // This caused a deadlock with no namenode becoming active during a startup after
+                // HDFS was completely down for a while.
+
                 hdfs_site_xml = HdfsSiteConfigBuilder::new(hdfs_name.to_string())
                     .dfs_namenode_name_dir()
                     .dfs_datanode_data_dir(merged_config.data_node_resources().map(|r| r.storage))
@@ -508,7 +517,6 @@ fn rolegroup_config_map(
                     .dfs_client_failover_proxy_provider()
                     .security_config(hdfs)
                     .add("dfs.ha.fencing.methods", "shell(/bin/true)")
-                    .add("dfs.ha.nn.not-become-active-in-safemode", "true")
                     .add("dfs.ha.automatic-failover.enabled", "true")
                     .add("dfs.ha.namenode.id", "${env.POD_NAME}")
                     // the extend with config must come last in order to have overrides working!!!


### PR DESCRIPTION
# Description

Change default value for `dfs.ha.nn.not-become-active-in-safemode` from true to false to be in line with the Hadoop default value.

This caused issues during a cold restart of an HDFS cluster for a user, due to both namenodes refusing to become active, hence creating a deadlock.

The relevant code in HDFS is shown below, and since this will never be skipped if `notBecomeActiveInSafemode` is true and the namenode is in safemode it can potentially delay startup a long time or even indefinitely.

```java
    if (notBecomeActiveInSafemode && isInSafeMode()) {
      throw new HealthCheckFailedException("The NameNode is configured to " +
          "report UNHEALTHY to ZKFC in Safemode.");
    }
```

fixes #264


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [x] Changelog updated
```

```[tasklist]
# Acceptance
- [x] Proper release label has been added
```
