### PR TITLE
chore: Lower requested resources in the logging test

### DIFF
--- a/tests/templates/kuttl/logging/03-install-hdfs-automatic-log.yaml.j2
+++ b/tests/templates/kuttl/logging/03-install-hdfs-automatic-log.yaml.j2
@@ -11,6 +11,13 @@ spec:
     vectorAggregatorConfigMapName: hdfs-vector-aggregator-discovery
     zookeeperConfigMapName: test-hdfs-automatic-log-znode
   nameNodes:
+    config:
+      resources:
+        memory:
+          limit: 256Mi
+        cpu:
+          max: 250m
+          min: 50m
     roleGroups:
       default:
         replicas: 2
@@ -59,6 +66,13 @@ spec:
                   ROOT:
                     level: INFO
   dataNodes:
+    config:
+      resources:
+        memory:
+          limit: 256Mi
+        cpu:
+          max: 250m
+          min: 50m
     roleGroups:
       default:
         replicas: 1
@@ -94,6 +108,13 @@ spec:
                   ROOT:
                     level: DEBUG
   journalNodes:
+    config:
+      resources:
+        memory:
+          limit: 256Mi
+        cpu:
+          max: 250m
+          min: 50m
     roleGroups:
       default:
         replicas: 1

--- a/tests/templates/kuttl/logging/03-install-hdfs-automatic-log.yaml.j2
+++ b/tests/templates/kuttl/logging/03-install-hdfs-automatic-log.yaml.j2
@@ -13,8 +13,6 @@ spec:
   nameNodes:
     config:
       resources:
-        memory:
-          limit: 256Mi
         cpu:
           max: 250m
           min: 50m
@@ -68,8 +66,6 @@ spec:
   dataNodes:
     config:
       resources:
-        memory:
-          limit: 256Mi
         cpu:
           max: 250m
           min: 50m
@@ -110,8 +106,6 @@ spec:
   journalNodes:
     config:
       resources:
-        memory:
-          limit: 256Mi
         cpu:
           max: 250m
           min: 50m

--- a/tests/templates/kuttl/logging/04-install-hdfs-custom-log.yaml.j2
+++ b/tests/templates/kuttl/logging/04-install-hdfs-custom-log.yaml.j2
@@ -70,8 +70,6 @@ spec:
   nameNodes:
     config:
       resources:
-        memory:
-          limit: 256Mi
         cpu:
           max: 250m
           min: 50m
@@ -97,8 +95,6 @@ spec:
   dataNodes:
     config:
       resources:
-        memory:
-          limit: 256Mi
         cpu:
           max: 250m
           min: 50m
@@ -118,8 +114,6 @@ spec:
   journalNodes:
     config:
       resources:
-        memory:
-          limit: 256Mi
         cpu:
           max: 250m
           min: 50m

--- a/tests/templates/kuttl/logging/04-install-hdfs-custom-log.yaml.j2
+++ b/tests/templates/kuttl/logging/04-install-hdfs-custom-log.yaml.j2
@@ -68,6 +68,13 @@ spec:
     vectorAggregatorConfigMapName: hdfs-vector-aggregator-discovery
     zookeeperConfigMapName: test-hdfs-custom-log-znode
   nameNodes:
+    config:
+      resources:
+        memory:
+          limit: 256Mi
+        cpu:
+          max: 250m
+          min: 50m
     roleGroups:
       default:
         replicas: 2
@@ -88,6 +95,13 @@ spec:
                 custom:
                   configMap: hdfs-format-zookeeper-log-config
   dataNodes:
+    config:
+      resources:
+        memory:
+          limit: 256Mi
+        cpu:
+          max: 250m
+          min: 50m
     roleGroups:
       default:
         replicas: 1
@@ -102,6 +116,13 @@ spec:
                 custom:
                   configMap: hdfs-wait-for-namenodes-log-config
   journalNodes:
+    config:
+      resources:
+        memory:
+          limit: 256Mi
+        cpu:
+          max: 250m
+          min: 50m
     roleGroups:
       default:
         replicas: 1

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -2,9 +2,8 @@
 dimensions:
   - name: hadoop
     values:
-      # - 3.2.4
+      - 3.2.4
       - 3.3.4
-      - 3.3.6
   - name: hadoop-latest
     values:
       - 3.3.4
@@ -41,32 +40,32 @@ dimensions:
       # This will *not* respect the kerberos-realm test attribute, but instead use a hard-coded realm
       # - activeDirectory
 tests:
-  # - name: smoke
-  #   dimensions:
-  #     - hadoop
-  #     - zookeeper
-  #     - zookeeper-latest # Needed for smoke test to detect if zk versions is the latest we support
-  #     - number-of-datanodes
-  #     - datanode-pvcs
-  #     - listener-class
-  # - name: kerberos
-  #   dimensions:
-  #     - hadoop-latest # We only support Kerberos for HDFS >= 3.3.x. See rust/operator/src/kerberos.rs for details
-  #     - zookeeper-latest
-  #     - kerberos-realm
-  #     - kerberos-backend
-  # - name: orphaned-resources
-  #   dimensions:
-  #     - hadoop-latest
-  #     - zookeeper-latest
+  - name: smoke
+    dimensions:
+      - hadoop
+      - zookeeper
+      - zookeeper-latest # Needed for smoke test to detect if zk versions is the latest we support
+      - number-of-datanodes
+      - datanode-pvcs
+      - listener-class
+  - name: kerberos
+    dimensions:
+      - hadoop-latest # We only support Kerberos for HDFS >= 3.3.x. See rust/operator/src/kerberos.rs for details
+      - zookeeper-latest
+      - kerberos-realm
+      - kerberos-backend
+  - name: orphaned-resources
+    dimensions:
+      - hadoop-latest
+      - zookeeper-latest
   - name: logging
     dimensions:
       - hadoop
       - zookeeper-latest
-  # - name: cluster-operation
-  #   dimensions:
-  #     - hadoop-latest
-  #     - zookeeper-latest
+  - name: cluster-operation
+    dimensions:
+      - hadoop-latest
+      - zookeeper-latest
   # Broken due to https://github.com/kudobuilder/kuttl/issues/322, see 40-assert.yaml for more details
   # - name: external-access
   #   dimensions:

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -2,8 +2,9 @@
 dimensions:
   - name: hadoop
     values:
-      - 3.2.4
+      # - 3.2.4
       - 3.3.4
+      - 3.3.6
   - name: hadoop-latest
     values:
       - 3.3.4
@@ -40,32 +41,32 @@ dimensions:
       # This will *not* respect the kerberos-realm test attribute, but instead use a hard-coded realm
       # - activeDirectory
 tests:
-  - name: smoke
-    dimensions:
-      - hadoop
-      - zookeeper
-      - zookeeper-latest # Needed for smoke test to detect if zk versions is the latest we support
-      - number-of-datanodes
-      - datanode-pvcs
-      - listener-class
-  - name: kerberos
-    dimensions:
-      - hadoop-latest # We only support Kerberos for HDFS >= 3.3.x. See rust/operator/src/kerberos.rs for details
-      - zookeeper-latest
-      - kerberos-realm
-      - kerberos-backend
-  - name: orphaned-resources
-    dimensions:
-      - hadoop-latest
-      - zookeeper-latest
+  # - name: smoke
+  #   dimensions:
+  #     - hadoop
+  #     - zookeeper
+  #     - zookeeper-latest # Needed for smoke test to detect if zk versions is the latest we support
+  #     - number-of-datanodes
+  #     - datanode-pvcs
+  #     - listener-class
+  # - name: kerberos
+  #   dimensions:
+  #     - hadoop-latest # We only support Kerberos for HDFS >= 3.3.x. See rust/operator/src/kerberos.rs for details
+  #     - zookeeper-latest
+  #     - kerberos-realm
+  #     - kerberos-backend
+  # - name: orphaned-resources
+  #   dimensions:
+  #     - hadoop-latest
+  #     - zookeeper-latest
   - name: logging
     dimensions:
       - hadoop
       - zookeeper-latest
-  - name: cluster-operation
-    dimensions:
-      - hadoop-latest
-      - zookeeper-latest
+  # - name: cluster-operation
+  #   dimensions:
+  #     - hadoop-latest
+  #     - zookeeper-latest
   # Broken due to https://github.com/kudobuilder/kuttl/issues/322, see 40-assert.yaml for more details
   # - name: external-access
   #   dimensions:


### PR DESCRIPTION
# Description

The logging test creates the following pods:

* hdfs-test-runner-0
* hdfs-vector-aggregator-0
* test-hdfs-automatic-log-datanode-default-0
* test-hdfs-automatic-log-journalnode-default-0
* test-hdfs-automatic-log-namenode-default-0
* test-hdfs-automatic-log-namenode-default-1
* test-hdfs-custom-log-datanode-default-0
* test-hdfs-custom-log-journalnode-default-0
* test-hdfs-custom-log-namenode-default-0
* test-hdfs-custom-log-namenode-default-1
* test-zk-server-default-0

They request a lot of CPU resources, especially because a Vector container is started for every HDFS pod.

The logging test usually passes if the other test which is running in parallel, does not request too much CPU. But if two logging tests for different Hadoop versions are running in parallel then not all pods can be scheduled (on our AKS cluster) due to insufficient CPU resources. If pods from both tests cannot be scheduled then the tests are deadlocked and will fail both.

Failed test due to deadlock: https://ci.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/hdfs-operator-it-custom/119/

The solution is to lower the requested resources.

This pull request lowers only the CPU requests for the HDFS containers because this can be easily done in the configuration. Lowering the requests for the Vector containers would require pod overrides (https://github.com/stackabletech/hdfs-operator/blob/23.11.0/rust/operator-binary/src/container.rs#L181-L187). However, this seems to be sufficient.

Successful test with lowered resources: https://ci.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/hdfs-operator-it-custom/121/