### PR TITLE
Change the liveness probes to use the web UI port and to fail after one minute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Use new label builders ([#454]).
+- Change the liveness probes to use the web UI port and to fail after
+  one minute ([#491]).
 
 ### Removed
 
@@ -35,6 +37,7 @@ All notable changes to this project will be documented in this file.
 [#462]: https://github.com/stackabletech/hdfs-operator/pull/462
 [#474]: https://github.com/stackabletech/hdfs-operator/pull/474
 [#475]: https://github.com/stackabletech/hdfs-operator/pull/475
+[#491]: https://github.com/stackabletech/hdfs-operator/pull/491
 
 ## [23.11.0] - 2023-11-24
 

--- a/rust/crd/src/constants.rs
+++ b/rust/crd/src/constants.rs
@@ -49,6 +49,13 @@ pub const DEFAULT_NAME_NODE_GRACEFUL_SHUTDOWN_TIMEOUT: Duration =
 pub const DEFAULT_DATA_NODE_GRACEFUL_SHUTDOWN_TIMEOUT: Duration =
     Duration::from_minutes_unchecked(30);
 
+pub const READINESS_PROBE_INITIAL_DELAY_SECONDS: i32 = 10;
+pub const READINESS_PROBE_PERIOD_SECONDS: i32 = 10;
+pub const READINESS_PROBE_FAILURE_THRESHOLD: i32 = 3;
+pub const LIVENESS_PROBE_INITIAL_DELAY_SECONDS: i32 = 10;
+pub const LIVENESS_PROBE_PERIOD_SECONDS: i32 = 10;
+pub const LIVENESS_PROBE_FAILURE_THRESHOLD: i32 = 5;
+
 // hdfs-site.xml
 pub const DFS_NAMENODE_NAME_DIR: &str = "dfs.namenode.name.dir";
 pub const DFS_NAMENODE_SHARED_EDITS_DIR: &str = "dfs.namenode.shared.edits.dir";


### PR DESCRIPTION
# Description

Change the liveness probes to use the web UI port and to fail after one minute

Fixes #488 

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [ ] Code contains useful logging statements
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
