### PR TITLE
fix(getting started): use cluster-internal listener class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Use new label builders ([#454]).
 - Change the liveness probes to use the web UI port and to fail after
   one minute ([#491]).
+- Update the getting started script to use the listener class cluster-internal ([#492])
 
 ### Removed
 
@@ -38,6 +39,7 @@ All notable changes to this project will be documented in this file.
 [#474]: https://github.com/stackabletech/hdfs-operator/pull/474
 [#475]: https://github.com/stackabletech/hdfs-operator/pull/475
 [#491]: https://github.com/stackabletech/hdfs-operator/pull/491
+[#492]: https://github.com/stackabletech/hdfs-operator/pull/492
 
 ## [23.11.0] - 2023-11-24
 

--- a/docs/modules/hdfs/examples/getting_started/getting_started.sh
+++ b/docs/modules/hdfs/examples/getting_started/getting_started.sh
@@ -118,10 +118,10 @@ echo "Awaiting helper rollout finish"
 # tag::watch-helper-rollout[]
 kubectl rollout status --watch --timeout=5m statefulset/webhdfs
 # end::watch-helper-rollout[]
-
+set -x
 file_status() {
   # tag::file-status[]
-  kubectl exec -n default webhdfs-0 -- curl -s -XGET "http://simple-hdfs-namenode-default-0:9870/webhdfs/v1/?op=LISTSTATUS"
+  kubectl exec -n default webhdfs-0 -- curl -s -XGET "http://listener-simple-hdfs-namenode-default-0:9870/webhdfs/v1/?op=LISTSTATUS"
   # end::file-status[]
 }
 
@@ -143,7 +143,7 @@ kubectl cp -n default ./testdata.txt webhdfs-0:/tmp
 create_file() {
   # tag::create-file[]
   kubectl exec -n default webhdfs-0 -- \
-  curl -s -XPUT -T /tmp/testdata.txt "http://simple-hdfs-namenode-default-0:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=CREATE&noredirect=true"
+  curl -s -XPUT -T /tmp/testdata.txt "http://listener-simple-hdfs-namenode-default-0:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=CREATE&noredirect=true"
   # end::create-file[]
 }
 
@@ -162,7 +162,7 @@ echo "Created file: $found_file with status $(file_status)"
 echo "Delete file"
 delete_file() {
   # tag::delete-file[]
-  kubectl exec -n default webhdfs-0 -- curl -s -XDELETE "http://simple-hdfs-namenode-default-0:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=DELETE"
+  kubectl exec -n default webhdfs-0 -- curl -s -XDELETE "http://listener-simple-hdfs-namenode-default-0:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=DELETE"
   # end::delete-file[]
 }
 

--- a/docs/modules/hdfs/examples/getting_started/getting_started.sh
+++ b/docs/modules/hdfs/examples/getting_started/getting_started.sh
@@ -118,10 +118,10 @@ echo "Awaiting helper rollout finish"
 # tag::watch-helper-rollout[]
 kubectl rollout status --watch --timeout=5m statefulset/webhdfs
 # end::watch-helper-rollout[]
-set -x
+
 file_status() {
   # tag::file-status[]
-  kubectl exec -n default webhdfs-0 -- curl -s -XGET "http://listener-simple-hdfs-namenode-default-0:9870/webhdfs/v1/?op=LISTSTATUS"
+  kubectl exec -n default webhdfs-0 -- curl -s -XGET "http://simple-hdfs-namenode-default-0.simple-hdfs-namenode-default.default.svc.cluster.local:9870/webhdfs/v1/?op=LISTSTATUS"
   # end::file-status[]
 }
 
@@ -143,7 +143,7 @@ kubectl cp -n default ./testdata.txt webhdfs-0:/tmp
 create_file() {
   # tag::create-file[]
   kubectl exec -n default webhdfs-0 -- \
-  curl -s -XPUT -T /tmp/testdata.txt "http://listener-simple-hdfs-namenode-default-0:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=CREATE&noredirect=true"
+  curl -s -XPUT -T /tmp/testdata.txt "http://simple-hdfs-namenode-default-0.simple-hdfs-namenode-default.default.svc.cluster.local:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=CREATE&noredirect=true"
   # end::create-file[]
 }
 
@@ -162,7 +162,7 @@ echo "Created file: $found_file with status $(file_status)"
 echo "Delete file"
 delete_file() {
   # tag::delete-file[]
-  kubectl exec -n default webhdfs-0 -- curl -s -XDELETE "http://listener-simple-hdfs-namenode-default-0:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=DELETE"
+  kubectl exec -n default webhdfs-0 -- curl -s -XDELETE "http://simple-hdfs-namenode-default-0.simple-hdfs-namenode-default.default.svc.cluster.local:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=DELETE"
   # end::delete-file[]
 }
 

--- a/docs/modules/hdfs/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/hdfs/examples/getting_started/getting_started.sh.j2
@@ -121,7 +121,7 @@ kubectl rollout status --watch --timeout=5m statefulset/webhdfs
 
 file_status() {
   # tag::file-status[]
-  kubectl exec -n default webhdfs-0 -- curl -s -XGET "http://simple-hdfs-namenode-default-0:9870/webhdfs/v1/?op=LISTSTATUS"
+  kubectl exec -n default webhdfs-0 -- curl -s -XGET "http://simple-hdfs-namenode-default-0.simple-hdfs-namenode-default.default.svc.cluster.local:9870/webhdfs/v1/?op=LISTSTATUS"
   # end::file-status[]
 }
 
@@ -143,7 +143,7 @@ kubectl cp -n default ./testdata.txt webhdfs-0:/tmp
 create_file() {
   # tag::create-file[]
   kubectl exec -n default webhdfs-0 -- \
-  curl -s -XPUT -T /tmp/testdata.txt "http://simple-hdfs-namenode-default-0:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=CREATE&noredirect=true"
+  curl -s -XPUT -T /tmp/testdata.txt "http://simple-hdfs-namenode-default-0.simple-hdfs-namenode-default.default.svc.cluster.local:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=CREATE&noredirect=true"
   # end::create-file[]
 }
 
@@ -162,7 +162,7 @@ echo "Created file: $found_file with status $(file_status)"
 echo "Delete file"
 delete_file() {
   # tag::delete-file[]
-  kubectl exec -n default webhdfs-0 -- curl -s -XDELETE "http://simple-hdfs-namenode-default-0:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=DELETE"
+  kubectl exec -n default webhdfs-0 -- curl -s -XDELETE "http://simple-hdfs-namenode-default-0.simple-hdfs-namenode-default.default.svc.cluster.local:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=DELETE"
   # end::delete-file[]
 }
 

--- a/docs/modules/hdfs/examples/getting_started/hdfs.yaml
+++ b/docs/modules/hdfs/examples/getting_started/hdfs.yaml
@@ -11,13 +11,13 @@ spec:
     dfsReplication: 1
   nameNodes:
     config:
-      listenerClass: external-stable
+      listenerClass: cluster-internal
     roleGroups:
       default:
         replicas: 2
   dataNodes:
     config:
-      listenerClass: external-unstable
+      listenerClass: cluster-internal
     roleGroups:
       default:
         replicas: 1


### PR DESCRIPTION
Fixes this problem:

```
❯ kubectl exec -n default webhdfs-0 -- curl -s -XGET "http://simple-hdfs-namenode-default-0:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=CREATE&noredirect=true"
command terminated with exit code 6
```