### PR TITLE
tests: added namespace patch for openshift tests

### DIFF
--- a/tests/release.yaml
+++ b/tests/release.yaml
@@ -1,7 +1,7 @@
 # Contains all operators required to run the test suite.
 ---
 releases:
-  # Do not change the name of the release as it's referenced from run_tests.sh
+  # Do not change the name of the release as it's referenced from run-tests
   tests:
     releaseDate: 1970-01-01
     description: Integration test

--- a/tests/templates/kuttl/cluster-operation/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/cluster-operation/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/external-access/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/external-access/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/kerberos/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/kerberos/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/logging/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/logging/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/orphaned-resources/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/orphaned-resources/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/profiling/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/profiling/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/smoke/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/smoke/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/topology-provider/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/topology-provider/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -51,6 +51,7 @@ tests:
       - number-of-datanodes
       - datanode-pvcs
       - listener-class
+      - openshift
   - name: kerberos
     dimensions:
       - hadoop-latest # We only support Kerberos for HDFS >= 3.3.x. See rust/operator/src/kerberos.rs for details
@@ -68,14 +69,17 @@ tests:
     dimensions:
       - hadoop-latest
       - zookeeper-latest
+      - openshift
   - name: logging
     dimensions:
       - hadoop
       - zookeeper-latest
+      - openshift
   - name: cluster-operation
     dimensions:
       - hadoop-latest
       - zookeeper-latest
+      - openshift
   - name: profiling
     dimensions:
       - hadoop


### PR DESCRIPTION
# Description

Part of stackabletech/issues#566.

OKD:

```
--- PASS: kuttl (2113.04s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/orphaned-resources_hadoop-latest-3.3.4_zookeeper-latest-3.9.1_openshift-true (220.82s)
        --- PASS: kuttl/harness/topology-provider_hadoop-latest-3.3.4_zookeeper-latest-3.9.1_kerberos-backend-mit_openshift-true (377.12s)
        --- PASS: kuttl/harness/smoke_hadoop-3.3.6_zookeeper-3.8.3_zookeeper-latest-3.9.1_number-of-datanodes-2_datanode-pvcs-2hdd-1ssd_listener-class-external-unstable_openshift-true (290.29s)
        --- PASS: kuttl/harness/logging_hadoop-3.3.6_zookeeper-latest-3.9.1_openshift-true (627.13s)
        --- PASS: kuttl/harness/cluster-operation_hadoop-latest-3.3.4_zookeeper-latest-3.9.1_openshift-true (231.11s)
        --- PASS: kuttl/harness/profiling_hadoop-3.3.6_zookeeper-latest-3.9.1_openshift-true (168.33s)
        --- PASS: kuttl/harness/kerberos_hadoop-latest-3.3.4_zookeeper-latest-3.9.1_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-true (1593.43s)
```


Azure:

```
--- PASS: kuttl (3422.01s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_hadoop-3.3.6_zookeeper-3.8.3_zookeeper-latest-3.9.1_number-of-datanodes-2_datanode-pvcs-2hdd-1ssd_listener-class-cluster-internal_openshift-false (335.59s)
        --- PASS: kuttl/harness/cluster-operation_hadoop-latest-3.3.4_zookeeper-latest-3.9.1_openshift-false (434.84s)
        --- PASS: kuttl/harness/profiling_hadoop-3.3.6_zookeeper-latest-3.9.1_openshift-false (278.95s)
        --- PASS: kuttl/harness/topology-provider_hadoop-latest-3.3.4_zookeeper-latest-3.9.1_kerberos-backend-mit_openshift-false (522.19s)
        --- PASS: kuttl/harness/orphaned-resources_hadoop-latest-3.3.4_zookeeper-latest-3.9.1_openshift-false (188.25s)
        --- PASS: kuttl/harness/smoke_hadoop-3.3.6_zookeeper-3.8.3_zookeeper-latest-3.9.1_number-of-datanodes-2_datanode-pvcs-2hdd-1ssd_listener-class-external-unstable_openshift-false (361.06s)
        --- PASS: kuttl/harness/logging_hadoop-3.3.6_zookeeper-latest-3.9.1_openshift-false (602.32s)
        --- PASS: kuttl/harness/kerberos_hadoop-latest-3.3.4_zookeeper-latest-3.9.1_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_openshift-false (1954.12s)
        --- PASS: kuttl/harness/kerberos_hadoop-latest-3.3.4_zookeeper-latest-3.9.1_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-false (2156.93s)
```



## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
