### PR TITLE
Update the krb5 image in the integration tests

### DIFF
--- a/tests/templates/kuttl/kerberos/01-install-krb5-kdc.yaml.j2
+++ b/tests/templates/kuttl/kerberos/01-install-krb5-kdc.yaml.j2
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: test-sa
       initContainers:
         - name: init
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
           args:
             - sh
             - -euo
@@ -36,7 +36,7 @@ spec:
               name: data
       containers:
         - name: kdc
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
           args:
             - krb5kdc
             - -n
@@ -54,7 +54,7 @@ spec:
             runAsUser: 0
 {% endif %}
         - name: kadmind
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
           args:
             - kadmind
             - -nofork
@@ -72,7 +72,7 @@ spec:
             runAsUser: 0
 {% endif %}
         - name: client
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
           tty: true
           stdin: true
           env:

--- a/tests/templates/kuttl/kerberos/01-install-krb5-kdc.yaml.j2
+++ b/tests/templates/kuttl/kerberos/01-install-krb5-kdc.yaml.j2
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: test-sa
       initContainers:
         - name: init
-          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           args:
             - sh
             - -euo
@@ -36,7 +36,7 @@ spec:
               name: data
       containers:
         - name: kdc
-          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           args:
             - krb5kdc
             - -n
@@ -54,7 +54,7 @@ spec:
             runAsUser: 0
 {% endif %}
         - name: kadmind
-          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           args:
             - kadmind
             - -nofork
@@ -72,7 +72,7 @@ spec:
             runAsUser: 0
 {% endif %}
         - name: client
-          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           tty: true
           stdin: true
           env:

--- a/tests/templates/kuttl/topology-provider/01-install-krb5-kdc.yaml.j2
+++ b/tests/templates/kuttl/topology-provider/01-install-krb5-kdc.yaml.j2
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: test-sa
       initContainers:
         - name: init
-          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           args:
             - sh
             - -euo
@@ -36,7 +36,7 @@ spec:
               name: data
       containers:
         - name: kdc
-          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           args:
             - krb5kdc
             - -n
@@ -54,7 +54,7 @@ spec:
             runAsUser: 0
 {% endif %}
         - name: kadmind
-          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           args:
             - kadmind
             - -nofork
@@ -67,7 +67,7 @@ spec:
             - mountPath: /var/kerberos/krb5kdc
               name: data
         - name: client
-          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           tty: true
           stdin: true
           env:

--- a/tests/templates/kuttl/topology-provider/01-install-krb5-kdc.yaml.j2
+++ b/tests/templates/kuttl/topology-provider/01-install-krb5-kdc.yaml.j2
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: test-sa
       initContainers:
         - name: init
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
           args:
             - sh
             - -euo
@@ -36,7 +36,7 @@ spec:
               name: data
       containers:
         - name: kdc
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
           args:
             - krb5kdc
             - -n
@@ -54,7 +54,7 @@ spec:
             runAsUser: 0
 {% endif %}
         - name: kadmind
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
           args:
             - kadmind
             - -nofork
@@ -67,7 +67,7 @@ spec:
             - mountPath: /var/kerberos/krb5kdc
               name: data
         - name: client
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
           tty: true
           stdin: true
           env:

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -16,7 +16,7 @@ dimensions:
   - name: zookeeper-latest
     values:
       - 3.9.1
-  - name: krb5-latest
+  - name: krb5
     values:
       - 1.21.1
   - name: number-of-datanodes
@@ -59,7 +59,7 @@ tests:
     dimensions:
       - hadoop-latest # We only support Kerberos for HDFS >= 3.3.x. See rust/operator/src/kerberos.rs for details
       - zookeeper-latest
-      - krb5-latest
+      - krb5
       - kerberos-realm
       - kerberos-backend
       - openshift
@@ -67,7 +67,7 @@ tests:
     dimensions:
       - hadoop-latest
       - zookeeper-latest
-      - krb5-latest
+      - krb5
       - kerberos-backend
       - openshift
   - name: orphaned-resources

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -16,6 +16,9 @@ dimensions:
   - name: zookeeper-latest
     values:
       - 3.9.1
+  - name: krb5-latest
+    values:
+      - 1.21.1
   - name: number-of-datanodes
     values:
       - "1"
@@ -56,6 +59,7 @@ tests:
     dimensions:
       - hadoop-latest # We only support Kerberos for HDFS >= 3.3.x. See rust/operator/src/kerberos.rs for details
       - zookeeper-latest
+      - krb5-latest
       - kerberos-realm
       - kerberos-backend
       - openshift
@@ -63,6 +67,7 @@ tests:
     dimensions:
       - hadoop-latest
       - zookeeper-latest
+      - krb5-latest
       - kerberos-backend
       - openshift
   - name: orphaned-resources


### PR DESCRIPTION
# Description

Update the krb5 image in the integration tests

The krb5 version was upgraded from 1.18.2 to 1.21.1 in stackabletech/docker-images#627. As the image with version 1.18.2 is not built anymore, it must be replaced in all integration tests.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
