### PR TITLE
test: update tests for envOverrides

### DIFF
--- a/tests/templates/kuttl/smoke/30-assert.yaml.j2
+++ b/tests/templates/kuttl/smoke/30-assert.yaml.j2
@@ -2,22 +2,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 timeout: 600
-commands:
-  #
-  # Test envOverrides for all roles
-  #
-  - script: |
-      kubectl -n $NAMESPACE get sts hdfs-datanode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "datanode") | .env[] | select (.name == "COMMON_VAR" and .value == "group-value")'
-      kubectl -n $NAMESPACE get sts hdfs-datanode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "datanode") | .env[] | select (.name == "GROUP_VAR" and .value == "group-value")'
-      kubectl -n $NAMESPACE get sts hdfs-datanode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "datanode") | .env[] | select (.name == "ROLE_VAR" and .value == "role-value")'
-  - script: |
-      kubectl -n $NAMESPACE get sts hdfs-journalnode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "journalnode") | .env[] | select (.name == "COMMON_VAR" and .value == "group-value")'
-      kubectl -n $NAMESPACE get sts hdfs-journalnode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "journalnode") | .env[] | select (.name == "GROUP_VAR" and .value == "group-value")'
-      kubectl -n $NAMESPACE get sts hdfs-journalnode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "journalnode") | .env[] | select (.name == "ROLE_VAR" and .value == "role-value")'
-  - script: |
-      kubectl -n $NAMESPACE get sts hdfs-namenode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "namenode") | .env[] | select (.name == "COMMON_VAR" and .value == "group-value")'
-      kubectl -n $NAMESPACE get sts hdfs-namenode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "namenode") | .env[] | select (.name == "GROUP_VAR" and .value == "group-value")'
-      kubectl -n $NAMESPACE get sts hdfs-namenode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "namenode") | .env[] | select (.name == "ROLE_VAR" and .value == "role-value")'
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/templates/kuttl/smoke/30-assert.yaml.j2
+++ b/tests/templates/kuttl/smoke/30-assert.yaml.j2
@@ -2,6 +2,22 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 timeout: 600
+commands:
+  #
+  # Test envOverrides for all roles
+  #
+  - script: |
+      kubectl -n $NAMESPACE get sts hdfs-datanode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "datanode") | .env[] | select (.name == "COMMON_VAR" and .value == "group-value")'
+      kubectl -n $NAMESPACE get sts hdfs-datanode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "datanode") | .env[] | select (.name == "GROUP_VAR" and .value == "group-value")'
+      kubectl -n $NAMESPACE get sts hdfs-datanode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "datanode") | .env[] | select (.name == "ROLE_VAR" and .value == "role-value")'
+  - script: |
+      kubectl -n $NAMESPACE get sts hdfs-journalnode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "journalnode") | .env[] | select (.name == "COMMON_VAR" and .value == "group-value")'
+      kubectl -n $NAMESPACE get sts hdfs-journalnode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "journalnode") | .env[] | select (.name == "GROUP_VAR" and .value == "group-value")'
+      kubectl -n $NAMESPACE get sts hdfs-journalnode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "journalnode") | .env[] | select (.name == "ROLE_VAR" and .value == "role-value")'
+  - script: |
+      kubectl -n $NAMESPACE get sts hdfs-namenode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "namenode") | .env[] | select (.name == "COMMON_VAR" and .value == "group-value")'
+      kubectl -n $NAMESPACE get sts hdfs-namenode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "namenode") | .env[] | select (.name == "GROUP_VAR" and .value == "group-value")'
+      kubectl -n $NAMESPACE get sts hdfs-namenode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "namenode") | .env[] | select (.name == "ROLE_VAR" and .value == "role-value")'
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/templates/kuttl/smoke/30-install-hdfs.yaml.j2
+++ b/tests/templates/kuttl/smoke/30-install-hdfs.yaml.j2
@@ -20,6 +20,9 @@ spec:
     vectorAggregatorConfigMapName: vector-aggregator-discovery
 {% endif %}
   nameNodes:
+    envOverrides:
+      COMMON_VAR: role-value # overridden by role group below
+      ROLE_VAR: role-value   # only defined here at role level
     config:
       listenerClass: {{ test_scenario['values']['listener-class'] }}
       logging:
@@ -27,7 +30,13 @@ spec:
     roleGroups:
       default:
         replicas: 2
+        envOverrides:
+          COMMON_VAR: group-value # overrides role value
+          GROUP_VAR: group-value # only defined here at group level
   dataNodes:
+    envOverrides:
+      COMMON_VAR: role-value # overridden by role group below
+      ROLE_VAR: role-value   # only defined here at role level
     config:
       listenerClass: {{ test_scenario['values']['listener-class'] }}
       logging:
@@ -49,13 +58,22 @@ spec:
 {% endif %}
     roleGroups:
       default:
+        envOverrides:
+          COMMON_VAR: group-value # overrides role value
+          GROUP_VAR: group-value # only defined here at group level
         replicas: {{ test_scenario['values']['number-of-datanodes'] }}
   journalNodes:
+    envOverrides:
+      COMMON_VAR: role-value # overridden by role group below
+      ROLE_VAR: role-value   # only defined here at role level
     config:
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
       default:
+        envOverrides:
+          COMMON_VAR: group-value # overrides role value
+          GROUP_VAR: group-value # only defined here at group level
         replicas: 1
         podOverrides:
           spec:

--- a/tests/templates/kuttl/smoke/31-assert.yaml
+++ b/tests/templates/kuttl/smoke/31-assert.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 600
+commands:
+  #
+  # Test envOverrides for all roles
+  #
+  - script: |
+      kubectl -n $NAMESPACE get sts hdfs-datanode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "datanode") | .env[] | select (.name == "COMMON_VAR" and .value == "group-value")'
+      kubectl -n $NAMESPACE get sts hdfs-datanode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "datanode") | .env[] | select (.name == "GROUP_VAR" and .value == "group-value")'
+      kubectl -n $NAMESPACE get sts hdfs-datanode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "datanode") | .env[] | select (.name == "ROLE_VAR" and .value == "role-value")'
+  - script: |
+      kubectl -n $NAMESPACE get sts hdfs-journalnode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "journalnode") | .env[] | select (.name == "COMMON_VAR" and .value == "group-value")'
+      kubectl -n $NAMESPACE get sts hdfs-journalnode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "journalnode") | .env[] | select (.name == "GROUP_VAR" and .value == "group-value")'
+      kubectl -n $NAMESPACE get sts hdfs-journalnode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "journalnode") | .env[] | select (.name == "ROLE_VAR" and .value == "role-value")'
+  - script: |
+      kubectl -n $NAMESPACE get sts hdfs-namenode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "namenode") | .env[] | select (.name == "COMMON_VAR" and .value == "group-value")'
+      kubectl -n $NAMESPACE get sts hdfs-namenode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "namenode") | .env[] | select (.name == "GROUP_VAR" and .value == "group-value")'
+      kubectl -n $NAMESPACE get sts hdfs-namenode-default -o yaml | yq -e '.spec.template.spec.containers[] | select (.name == "namenode") | .env[] | select (.name == "ROLE_VAR" and .value == "role-value")'


### PR DESCRIPTION
# Description

Part of : https://github.com/stackabletech/issues/issues/548

:green_circle: Test:

```
--- PASS: kuttl (147.39s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.0_zookeeper-3.9.2_zookeeper-latest-3.9.2_number-of-datanodes-2_datanode-pvcs-2hdd-1ssd_listener-class-external-unstable_openshift-false (147.37s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [x] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
