### PR TITLE
test: Run kerberos test on all HDFS versions

### DIFF
--- a/tests/templates/kuttl/kerberos/20-install-hdfs.txt.j2
+++ b/tests/templates/kuttl/kerberos/20-install-hdfs.txt.j2
@@ -5,11 +5,11 @@ metadata:
   name: hdfs
 spec:
   image:
-{% if test_scenario['values']['hadoop-latest'].find(",") > 0 %}
-    custom: "{{ test_scenario['values']['hadoop-latest'].split(',')[1] }}"
-    productVersion: "{{ test_scenario['values']['hadoop-latest'].split(',')[0] }}"
+{% if test_scenario['values']['hadoop'].find(",") > 0 %}
+    custom: "{{ test_scenario['values']['hadoop'].split(',')[1] }}"
+    productVersion: "{{ test_scenario['values']['hadoop'].split(',')[0] }}"
 {% else %}
-    productVersion: "{{ test_scenario['values']['hadoop-latest'] }}"
+    productVersion: "{{ test_scenario['values']['hadoop'] }}"
 {% endif %}
     pullPolicy: IfNotPresent
   clusterConfig:

--- a/tests/templates/kuttl/kerberos/30-access-hdfs.txt.j2
+++ b/tests/templates/kuttl/kerberos/30-access-hdfs.txt.j2
@@ -9,10 +9,10 @@ spec:
       serviceAccountName: test-sa
       containers:
         - name: access-hdfs
-{% if test_scenario['values']['hadoop-latest'].find(",") > 0 %}
-          image: "{{ test_scenario['values']['hadoop-latest'].split(',')[1] }}"
+{% if test_scenario['values']['hadoop'].find(",") > 0 %}
+          image: "{{ test_scenario['values']['hadoop'].split(',')[1] }}"
 {% else %}
-          image: docker.stackable.tech/stackable/hadoop:{{ test_scenario['values']['hadoop-latest'] }}-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/hadoop:{{ test_scenario['values']['hadoop'] }}-stackable0.0.0-dev
 {% endif %}
           env:
             - name: HADOOP_CONF_DIR

--- a/tests/templates/kuttl/kerberos/32-check-file.txt.j2
+++ b/tests/templates/kuttl/kerberos/32-check-file.txt.j2
@@ -9,10 +9,10 @@ spec:
       serviceAccountName: test-sa
       containers:
         - name: check-hdfs
-{% if test_scenario['values']['hadoop-latest'].find(",") > 0 %}
-          image: "{{ test_scenario['values']['hadoop-latest'].split(',')[1] }}"
+{% if test_scenario['values']['hadoop'].find(",") > 0 %}
+          image: "{{ test_scenario['values']['hadoop'].split(',')[1] }}"
 {% else %}
-          image: docker.stackable.tech/stackable/hadoop:{{ test_scenario['values']['hadoop-latest'] }}-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/hadoop:{{ test_scenario['values']['hadoop'] }}-stackable0.0.0-dev
 {% endif %}
           env:
             - name: HADOOP_CONF_DIR

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -62,7 +62,7 @@ tests:
       - openshift
   - name: kerberos
     dimensions:
-      - hadoop-latest # We only support Kerberos for HDFS >= 3.3.x. See rust/operator/src/kerberos.rs for details
+      - hadoop
       - zookeeper-latest
       - krb5
       - kerberos-realm


### PR DESCRIPTION
# Description

Noticed during https://github.com/stackabletech/docker-images/pull/914
All currently supported versions support Kerberos, so we should test them :)

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
