### PR TITLE
tests: Add OPA as a test dimension (main)

### DIFF
--- a/tests/templates/kuttl/kerberos/11-install-opa.yaml.j2
+++ b/tests/templates/kuttl/kerberos/11-install-opa.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: opa
 spec:
   image:
-    productVersion: 0.61.0
+    productVersion: "{{ test_scenario['values']['opa'] }}"
   servers:
     roleGroups:
       default: {}

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -24,6 +24,9 @@ dimensions:
   - name: krb5
     values:
       - 1.21.1
+  - name: opa
+    values:
+      - 0.67.1
   - name: number-of-datanodes
     values:
       - "1"
@@ -68,6 +71,7 @@ tests:
       - kerberos-realm
       - kerberos-backend
       - openshift
+      - opa
   - name: topology-provider
     dimensions:
       - hadoop-latest


### PR DESCRIPTION
Replace hard-coded OPA version with a templated dimension.

There is a companion change for the release-24.11 branch: #613.