### PR TITLE
chore: Switch liveness probe to tcp socket instead of httpGet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
   config property `requestedSecretLifetime`. This helps reducing frequent Pod restarts ([#619]).
 - Run a `containerdebug` process in the background of each HDFS container to collect debugging information ([#629]).
 
+### Changed
+
+- Switch the WebUI liveness probe from `httpGet` to checking the tcp socket.
+  This helps with setups where configOverrides are used to enable security on the HTTP interfaces.
+  As this results in `401` HTTP responses (instead of `200`), this previously failed the liveness checks.
+
 ### Fixed
 
 - BREAKING: Use distinct ServiceAccounts for the Stacklets, so that multiple Stacklets can be

--- a/rust/operator-binary/src/container.rs
+++ b/rust/operator-binary/src/container.rs
@@ -964,6 +964,7 @@ wait_for_termination $!
         };
 
         Some(Probe {
+            // Use tcp_socket instead of http_get so that the probe is independent of the authentication settings.
             tcp_socket: Some(Self::tcp_socket_action_for_port(*port)),
             period_seconds: Some(period_seconds),
             initial_delay_seconds: Some(initial_delay_seconds),

--- a/rust/operator-binary/src/container.rs
+++ b/rust/operator-binary/src/container.rs
@@ -157,15 +157,6 @@ pub enum ContainerConfig {
         web_ui_http_port_name: &'static str,
         /// Port name of the web UI HTTPS port, used for the liveness probe.
         web_ui_https_port_name: &'static str,
-        /// Path of the web UI URL; The path defaults to / in Kubernetes
-        /// and the kubelet follows redirects. The default would work if
-        /// the location header is set properly but that is not the case
-        /// for the DataNode. On a TLS-enabled DataNode, calling
-        /// https://127.0.0.1:9865/ redirects to the non-TLS URL
-        /// http://127.0.0.1:9865/index.html which causes the liveness
-        /// probe to fail. So it is best to not rely on the location
-        /// header but instead provide the resolved path directly.
-        web_ui_path: &'static str,
         /// The JMX Exporter metrics port.
         metrics_port: u16,
     },
@@ -1383,7 +1374,6 @@ impl From<HdfsRole> for ContainerConfig {
                 ipc_port_name: SERVICE_PORT_NAME_RPC,
                 web_ui_http_port_name: SERVICE_PORT_NAME_HTTP,
                 web_ui_https_port_name: SERVICE_PORT_NAME_HTTPS,
-                web_ui_path: "/dfshealth.html",
                 metrics_port: DEFAULT_NAME_NODE_METRICS_PORT,
             },
             HdfsRole::DataNode => Self::Hdfs {
@@ -1393,7 +1383,6 @@ impl From<HdfsRole> for ContainerConfig {
                 ipc_port_name: SERVICE_PORT_NAME_IPC,
                 web_ui_http_port_name: SERVICE_PORT_NAME_HTTP,
                 web_ui_https_port_name: SERVICE_PORT_NAME_HTTPS,
-                web_ui_path: "/datanode.html",
                 metrics_port: DEFAULT_DATA_NODE_METRICS_PORT,
             },
             HdfsRole::JournalNode => Self::Hdfs {
@@ -1403,7 +1392,6 @@ impl From<HdfsRole> for ContainerConfig {
                 ipc_port_name: SERVICE_PORT_NAME_RPC,
                 web_ui_http_port_name: SERVICE_PORT_NAME_HTTP,
                 web_ui_https_port_name: SERVICE_PORT_NAME_HTTPS,
-                web_ui_path: "/journalnode.html",
                 metrics_port: DEFAULT_JOURNAL_NODE_METRICS_PORT,
             },
         }


### PR DESCRIPTION
# Description

In SUP-159 a customer wanted to enable security for the Namenode HTTP API.
This resulted in `/dfshealth.html` returning a 401 instead of a 200 - thus failing the liveness probe.

This PR allows customers to configOverride security for the HTTP APIs (hopefully until we support them natively)

We intentionally did *not* write a curl script that checks for 200 or 401 but just went with the TCP port.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
