### PR TITLE
test: Reduce number of smoke tests by skipping Zookeeper 3.9.2

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -18,7 +18,7 @@ dimensions:
       - 3.3.6
   - name: zookeeper
     values:
-      - 3.9.2
+      # - 3.9.2 => The patch level bump is not worth it doubling the number of the smoke test (the number is already gigantic)
       - 3.9.3
   - name: zookeeper-latest
     values:


### PR DESCRIPTION
# Description

Follow-up of https://github.com/stackabletech/hdfs-operator/pull/657.
https://testing.stackable.tech/job/hdfs-operator-it-weekly/48/ and https://testing.stackable.tech/job/hdfs-operator-it-weekly/49/ took more than 6 hours, so longern than our replicated cluster TTL, thus failing

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
