### PR TITLE
test: Remove ZooKeeper 3.9.2

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -18,7 +18,6 @@ dimensions:
       - 3.3.6
   - name: zookeeper
     values:
-      # - 3.9.2 => The patch level bump is not worth it doubling the number of the smoke test (the number is already gigantic)
       - 3.9.3
   - name: zookeeper-latest
     values:


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1083.

- Remove commented out ZooKeeper 3.9.2 from tests

> [!NOTE]
> I didn't update the changelog since there is no real change.
