### PR TITLE
chore: Remove support for HDFS 3.3.4, 3.3.6, 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,16 @@ All notable changes to this project will be documented in this file.
 - Use `json` file extension for log files ([#667]).
 - Fix a bug where changes to ConfigMaps that are referenced in the HdfsCluster spec didn't trigger a reconciliation ([#671]).
 
+### Removed
+
+- Remove support for HDFS `3.3.4`, `3.3.6`, and `3.4.0` ([#675]).
+
 [#661]: https://github.com/stackabletech/hdfs-operator/pull/661
 [#671]: https://github.com/stackabletech/hdfs-operator/pull/671
 [#667]: https://github.com/stackabletech/hdfs-operator/pull/667
 [#668]: https://github.com/stackabletech/hdfs-operator/pull/668
 [#672]: https://github.com/stackabletech/hdfs-operator/pull/672
+[#675]: https://github.com/stackabletech/hdfs-operator/pull/675
 
 ## [25.3.0] - 2025-03-21
 

--- a/docs/modules/hdfs/partials/supported-versions.adoc
+++ b/docs/modules/hdfs/partials/supported-versions.adoc
@@ -3,6 +3,3 @@
 // Stackable Platform documentation.
 
 - 3.4.1 (LTS)
-- 3.4.0 (deprecated)
-- 3.3.6 (deprecated) - Please note that there is a https://github.com/stackabletech/hdfs-operator/issues/440[known issue] related to NameNode bootstrapping which can happen in rare cases.
-- 3.3.4 (deprecated)

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -2,9 +2,6 @@
 dimensions:
   - name: hadoop
     values:
-      - 3.3.4
-      - 3.3.6
-      - 3.4.0
       - 3.4.1
       # To use a custom image, add a comma and the full name after the product version
       # - 3.4.1,oci.stackable.tech/sandbox/hadoop:3.4.1-stackable0.0.0-dev
@@ -15,7 +12,7 @@ dimensions:
       # - 3.4.1,oci.stackable.tech/sandbox/hadoop:3.4.1-stackable0.0.0-dev
   - name: hadoop-external-client-docker-image
     values:
-      - 3.3.6
+      - 3.4.1
   - name: zookeeper
     values:
       - 3.9.3


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1077.

- Remove support for `3.3.4`, `3.3.6`, `3.4.0`

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

# Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible

# Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

# Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
