### PR TITLE
test: Bump vector to 0.46.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
   - Replace stackable-operator `print_startup_string` with `tracing::info!` with fields.
 - BREAKING: Inject the vector aggregator address into the vector config using the env var `VECTOR_AGGREGATOR_ADDRESS` instead
     of having the operator write it to the vector config ([#671]).
+- test: Bump to Vector `0.46.1` ([#677]).
 
 ### Fixed
 
@@ -37,6 +38,7 @@ All notable changes to this project will be documented in this file.
 [#668]: https://github.com/stackabletech/hdfs-operator/pull/668
 [#672]: https://github.com/stackabletech/hdfs-operator/pull/672
 [#675]: https://github.com/stackabletech/hdfs-operator/pull/675
+[#677]: https://github.com/stackabletech/hdfs-operator/pull/677
 
 ## [25.3.0] - 2025-03-21
 

--- a/tests/templates/kuttl/logging/01-install-hdfs-vector-aggregator.yaml
+++ b/tests/templates/kuttl/logging/01-install-hdfs-vector-aggregator.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install hdfs-vector-aggregator vector
       --namespace $NAMESPACE
-      --version 0.39.0
+      --version 0.42.1
       --repo https://helm.vector.dev
       --values hdfs-vector-aggregator-values.yaml
 ---


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1085.

- Bump to Vector 0.46.1 (chart version 0.42.1) in tests

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
