### PR TITLE
chore: Remove hardcoded uid and gid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ All notable changes to this project will be documented in this file.
 - BREAKING: Inject the vector aggregator address into the vector config using the env var `VECTOR_AGGREGATOR_ADDRESS` instead
     of having the operator write it to the vector config ([#671]).
 - test: Bump to Vector `0.46.1` ([#677]).
+- BREAKING: Previously this operator would hardcode the UID and GID of the Pods being created to 1000/0, this has changed now ([#683])
+  - The `runAsUser` and `runAsGroup` fields will not be set anymore by the operator
+  - The defaults from the docker images itself will now apply, which will be different from 1000/0 going forward
+  - This is marked as breaking because tools and policies might exist, which require these fields to be set
 
 ### Fixed
 
@@ -39,6 +43,7 @@ All notable changes to this project will be documented in this file.
 [#672]: https://github.com/stackabletech/hdfs-operator/pull/672
 [#675]: https://github.com/stackabletech/hdfs-operator/pull/675
 [#677]: https://github.com/stackabletech/hdfs-operator/pull/677
+[#683]: https://github.com/stackabletech/hdfs-operator/pull/683
 
 ## [25.3.0] - 2025-03-21
 

--- a/rust/operator-binary/src/crd/constants.rs
+++ b/rust/operator-binary/src/crd/constants.rs
@@ -82,5 +82,3 @@ pub const DATANODE_ROOT_DATA_DIR_SUFFIX: &str = "/datanode";
 
 pub const LISTENER_VOLUME_NAME: &str = "listener";
 pub const LISTENER_VOLUME_DIR: &str = "/stackable/listener";
-
-pub const HDFS_UID: i64 = 1000;

--- a/rust/operator-binary/src/hdfs_controller.rs
+++ b/rust/operator-binary/src/hdfs_controller.rs
@@ -827,13 +827,7 @@ fn rolegroup_statefulset(
         .image_pull_secrets_from_product_image(resolved_product_image)
         .affinity(&merged_config.affinity)
         .service_account_name(service_account.name_any())
-        .security_context(
-            PodSecurityContextBuilder::new()
-                .run_as_user(HDFS_UID)
-                .run_as_group(0)
-                .fs_group(1000)
-                .build(),
-        );
+        .security_context(PodSecurityContextBuilder::new().fs_group(1000).build());
 
     // Adds all containers and volumes to the pod builder
     // We must use the selector labels ("rolegroup_selector_labels") and not the recommended labels

--- a/tests/templates/kuttl/kerberos/30-access-hdfs.txt.j2
+++ b/tests/templates/kuttl/kerberos/30-access-hdfs.txt.j2
@@ -86,6 +86,4 @@ spec:
                     storage: "1"
       securityContext:
         fsGroup: 1000
-        runAsGroup: 1000
-        runAsUser: 1000
       restartPolicy: OnFailure

--- a/tests/templates/kuttl/kerberos/32-check-file.txt.j2
+++ b/tests/templates/kuttl/kerberos/32-check-file.txt.j2
@@ -58,6 +58,4 @@ spec:
                     storage: "1"
       securityContext:
         fsGroup: 1000
-        runAsGroup: 1000
-        runAsUser: 1000
       restartPolicy: OnFailure

--- a/tests/templates/kuttl/topology-provider/20-access-hdfs.yaml.j2
+++ b/tests/templates/kuttl/topology-provider/20-access-hdfs.yaml.j2
@@ -64,7 +64,5 @@ commands:
                           storage: "1"
             securityContext:
               fsGroup: 1000
-              runAsGroup: 1000
-              runAsUser: 1000
             restartPolicy: OnFailure
       EOF


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/651

Remove hardcoded uid and gid, they'll default to the ones from the docker images now.
For 25.7 that means they might change from 1000/0
See https://github.com/stackabletech/docker-images/pull/916 for details

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Changes are OpenShift compatible
- [x] Integration tests passed (for non trivial changes)

### Reviewer

- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Changelog updated

### Acceptance

- [ ] Proper release label has been added

