### PR TITLE
Add cipher suite (AES/CTR/NoPadding) per default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
   - Use `--file-log-max-files` (or `FILE_LOG_MAX_FILES`) to limit the number of log files kept.
   - Use `--file-log-rotation-period` (or `FILE_LOG_ROTATION_PERIOD`) to configure the frequency of rotation.
   - Use `--console-log-format` (or `CONSOLE_LOG_FORMAT`) to set the format to `plain` (default) or `json`.
-- The operator now sets defaults for `dfs.encrypt.data.transfer.cipher.suite` (`AES/CTR/NoPadding`) and `dfs.encrypt.data.transfer.cipher.key.bitlength` (`128`) to improve security and performance ([#693]).
+- The operator now defaults to `AES/CTR/NoPadding` for `dfs.encrypt.data.transfer.cipher.suite` to improve security and performance ([#693]).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
   - Use `--file-log-max-files` (or `FILE_LOG_MAX_FILES`) to limit the number of log files kept.
   - Use `--file-log-rotation-period` (or `FILE_LOG_ROTATION_PERIOD`) to configure the frequency of rotation.
   - Use `--console-log-format` (or `CONSOLE_LOG_FORMAT`) to set the format to `plain` (default) or `json`.
+- The operator now sets defaults for `dfs.encrypt.data.transfer.cipher.suite` (`AES/CTR/NoPadding`) and `dfs.encrypt.data.transfer.cipher.key.bitlength` (`128`) to improve security and performance ([#693]).
 
 ### Changed
 
@@ -46,6 +47,7 @@ All notable changes to this project will be documented in this file.
 [#677]: https://github.com/stackabletech/hdfs-operator/pull/677
 [#683]: https://github.com/stackabletech/hdfs-operator/pull/683
 [#684]: https://github.com/stackabletech/hdfs-operator/pull/684
+[#693]: https://github.com/stackabletech/hdfs-operator/pull/693
 
 ## [25.3.0] - 2025-03-21
 

--- a/docs/modules/hdfs/pages/usage-guide/security.adoc
+++ b/docs/modules/hdfs/pages/usage-guide/security.adoc
@@ -33,7 +33,7 @@ The `kerberos.secretClass` is used to give HDFS the possibility to request keyta
 
 The `tlsSecretClass` is needed to request TLS certificates, used e.g. for the Web UIs.
 
-NOTE: The hdfs-operator defaults to `AES/CTR/NoPadding` for `dfs.encrypt.data.transfer.cipher.suite` with a default key length of 128 Bit. This can be changed using config overrides.
+NOTE: The hdfs-operator defaults to `AES/CTR/NoPadding` for `dfs.encrypt.data.transfer.cipher.suite`. This can be changed using config overrides.
 
 === 4. Verify that Kerberos authentication is required
 Use `stackablectl stacklet list` to get the endpoints where the HDFS namenodes are reachable.

--- a/docs/modules/hdfs/pages/usage-guide/security.adoc
+++ b/docs/modules/hdfs/pages/usage-guide/security.adoc
@@ -33,7 +33,7 @@ The `kerberos.secretClass` is used to give HDFS the possibility to request keyta
 
 The `tlsSecretClass` is needed to request TLS certificates, used e.g. for the Web UIs.
 
-NOTE: The hdfs-operator uses the cipher suite `AES/CTR/NoPadding` with a 128 Bit key per default. This can be changed using config overrides.
+NOTE: The hdfs-operator defaults to `AES/CTR/NoPadding` for `dfs.encrypt.data.transfer.cipher.suite` with a default key length of 128 Bit. This can be changed using config overrides.
 
 === 4. Verify that Kerberos authentication is required
 Use `stackablectl stacklet list` to get the endpoints where the HDFS namenodes are reachable.

--- a/docs/modules/hdfs/pages/usage-guide/security.adoc
+++ b/docs/modules/hdfs/pages/usage-guide/security.adoc
@@ -33,6 +33,7 @@ The `kerberos.secretClass` is used to give HDFS the possibility to request keyta
 
 The `tlsSecretClass` is needed to request TLS certificates, used e.g. for the Web UIs.
 
+NOTE: The hdfs-operator uses the cipher suite `AES/CTR/NoPadding` with a 128 Bit key per default. This can be changed using config overrides.
 
 === 4. Verify that Kerberos authentication is required
 Use `stackablectl stacklet list` to get the endpoints where the HDFS namenodes are reachable.

--- a/rust/operator-binary/src/security/kerberos.rs
+++ b/rust/operator-binary/src/security/kerberos.rs
@@ -56,7 +56,6 @@ impl HdfsSiteConfigBuilder {
             "dfs.encrypt.data.transfer.cipher.suite",
             "AES/CTR/NoPadding",
         );
-        self.add("dfs.encrypt.data.transfer.cipher.key.bitlength", "128");
         self
     }
 }

--- a/rust/operator-binary/src/security/kerberos.rs
+++ b/rust/operator-binary/src/security/kerberos.rs
@@ -52,6 +52,11 @@ impl HdfsSiteConfigBuilder {
     fn add_wire_encryption_settings(&mut self) -> &mut Self {
         self.add("dfs.data.transfer.protection", "privacy");
         self.add("dfs.encrypt.data.transfer", "true");
+        self.add(
+            "dfs.encrypt.data.transfer.cipher.suite",
+            "AES/CTR/NoPadding",
+        );
+        self.add("dfs.encrypt.data.transfer.cipher.key.bitlength", "128");
         self
     }
 }


### PR DESCRIPTION
## Description

fixes https://github.com/stackabletech/hdfs-operator/issues/680

The hdfs-operator now defaults to `AES/CTR/NoPadding` for `dfs.encrypt.data.transfer.cipher.suite` to improve security and performance

**hdfs-site.xml:**
```
<property>
  <name>dfs.data.transfer.protection</name>
  <value>privacy</value>
</property>
<property>
  <name>dfs.encrypt.data.transfer</name>
  <value>true</value>
</property>                                                                                  
<property>
  <name>dfs.encrypt.data.transfer.cipher.suite</name>
  <value>AES/CTR/NoPadding</value>                                                                                   
</property>
```

**Test:**
```
--- PASS: kuttl (608.24s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/kerberos_hadoop-3.4.1_zookeeper-latest-3.9.3_krb5-1.21.1_opa-1.4.2_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-false (608.23s)
```