### PR TITLE
fix: remove legacy service account binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
   - The defaults from the docker images itself will now apply, which will be different from 1000/0 going forward
   - This is marked as breaking because tools and policies might exist, which require these fields to be set
 - Use versioned common structs ([#684]).
+- BREAKING: remove legacy service account binding for cluster role nodes ([#697]).
 
 ### Fixed
 
@@ -50,6 +51,7 @@ All notable changes to this project will be documented in this file.
 [#684]: https://github.com/stackabletech/hdfs-operator/pull/684
 [#693]: https://github.com/stackabletech/hdfs-operator/pull/693
 [#695]: https://github.com/stackabletech/hdfs-operator/pull/695
+[#697]: https://github.com/stackabletech/hdfs-operator/pull/697
 
 ## [25.3.0] - 2025-03-21
 

--- a/rust/operator-binary/src/hdfs_clusterrolebinding_nodes_controller.rs
+++ b/rust/operator-binary/src/hdfs_clusterrolebinding_nodes_controller.rs
@@ -73,26 +73,12 @@ pub async fn reconcile(
             }
         })
         .flat_map(|(meta, sa_name)| {
-            let mut result = vec![
-                Subject {
-                    kind: "ServiceAccount".to_string(),
-                    name: sa_name,
-                    namespace: meta.namespace.clone(),
-                    ..Subject::default()
-                },
-                // This extra Serviceaccount is being written for legacy/compatibility purposes
-                // to ensure that running clusters don't lose access to anything during an upgrade
-                // of the Stackable operators, this code can be removed in later releases
-                // The value is hardcoded here, as we have removed access to the private fns that
-                // would have built it, since this is a known target though, and will be removed soon
-                // this should not be an issue.
-                Subject {
-                    kind: "ServiceAccount".to_string(),
-                    name: "hdfs-serviceaccount".to_string(),
-                    namespace: meta.namespace.clone(),
-                    ..Subject::default()
-                },
-            ];
+            let mut result = vec![Subject {
+                kind: "ServiceAccount".to_string(),
+                name: sa_name,
+                namespace: meta.namespace.clone(),
+                ..Subject::default()
+            }];
             // If a cluster is called hdfs this would result in the same subject
             // being written twicex.
             // Since we know this vec only contains two elements we can use dedup for

--- a/rust/operator-binary/src/hdfs_clusterrolebinding_nodes_controller.rs
+++ b/rust/operator-binary/src/hdfs_clusterrolebinding_nodes_controller.rs
@@ -72,19 +72,11 @@ pub async fn reconcile(
                 }
             }
         })
-        .flat_map(|(meta, sa_name)| {
-            let mut result = vec![Subject {
-                kind: "ServiceAccount".to_string(),
-                name: sa_name,
-                namespace: meta.namespace.clone(),
-                ..Subject::default()
-            }];
-            // If a cluster is called hdfs this would result in the same subject
-            // being written twicex.
-            // Since we know this vec only contains two elements we can use dedup for
-            // simply removing this duplicate.
-            result.dedup();
-            result
+        .map(|(meta, sa_name)| Subject {
+            kind: "ServiceAccount".to_string(),
+            name: sa_name,
+            namespace: meta.namespace.clone(),
+            ..Subject::default()
         })
         .collect();
 


### PR DESCRIPTION
## Description

Part of: https://github.com/stackabletech/operator-rs/issues/1005
and the related pr: https://github.com/stackabletech/operator-rs/pull/1060

> [!IMPORTANT]
> [in an unrelated PR](https://github.com/stackabletech/hdfs-operator/pull/696/files#diff-ed333b8f35d2ccba68a23b248c72c694150349eff25b065b5622579c72a8e165) I added stackable generic labels to the node cluster role to aid resource cleanup. Can the reviewer please check if that interferes with the locality behaviour? @soenkeliebau 

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [x] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
