### PR TITLE
Add test for native library support

### DIFF
--- a/tests/templates/kuttl/smoke/52-assert.yaml
+++ b/tests/templates/kuttl/smoke/52-assert.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: kubectl exec -n $NAMESPACE hdfs-namenode-default-0 -- hadoop checknative | grep "hadoop:.*true"
+  - script: kubectl exec -n $NAMESPACE hdfs-namenode-default-0 -- hadoop checknative | grep "zlib:.*true"
+  - script: kubectl exec -n $NAMESPACE hdfs-namenode-default-0 -- hadoop checknative | grep "openssl:.*true"


### PR DESCRIPTION
## Description

Add test for native library support

All integration tests succeed after with the fix from https://github.com/stackabletech/docker-images/pull/1209:

```
📈 Loaded runtime history for 4 tests
Starting Automated Test Suite with Retry Logic
==============================================

Step 1: Running initial full test suite...
  All tests passed on initial run!

📊 Generating final report...
================================================================================
AUTOMATED TEST SUITE REPORT
==============================================
Started: 2025-07-18 13:07:03
Ended: 2025-07-18 13:23:24
Total Duration: 0:16:21.453104

SUMMARY
----------------------------------------------
Total Tests: 0
Passed: 0
Flaky (eventually passed): 0
Failed: 0
Success Rate: 0.0%

RUNTIME STATISTICS
----------------------------------------------
Total test runs recorded: 4
Overall average runtime: 2.5m
Overall median runtime: 2.5m
Fastest test run: 2.5m
Slowest test run: 2.5m

Slowest tests (by average):
  smoke_hadoop-3.4.1,host.k3d.internal_5000_lars_hadoop_3.4.1-stackable0.0.0-dev_zookeeper-3.9.3_zookeeper-latest-3.9.3_number-of-datanodes-2_datanode-pvcs-default_listener-class-external-unstable_openshift-false: 2.5m
  smoke_hadoop-3.4.1,host.k3d.internal_5000_lars_hadoop_3.4.1-stackable0.0.0-dev_zookeeper-3.9.3_zookeeper-latest-3.9.3_number-of-datanodes-2_datanode-pvcs-default_listener-class-cluster-internal_openshift-false: 2.5m
  smoke_hadoop-3.4.1,host.k3d.internal_5000_lars_hadoop_3.4.1-stackable0.0.0-dev_zookeeper-3.9.3_zookeeper-latest-3.9.3_number-of-datanodes-1_datanode-pvcs-default_listener-class-cluster-internal_openshift-false: 2.5m

Fastest tests (by average):
  smoke_hadoop-3.4.1,host.k3d.internal_5000_lars_hadoop_3.4.1-stackable0.0.0-dev_zookeeper-3.9.3_zookeeper-latest-3.9.3_number-of-datanodes-2_datanode-pvcs-default_listener-class-cluster-internal_openshift-false: 2.5m
  smoke_hadoop-3.4.1,host.k3d.internal_5000_lars_hadoop_3.4.1-stackable0.0.0-dev_zookeeper-3.9.3_zookeeper-latest-3.9.3_number-of-datanodes-1_datanode-pvcs-default_listener-class-cluster-internal_openshift-false: 2.5m
  smoke_hadoop-3.4.1,host.k3d.internal_5000_lars_hadoop_3.4.1-stackable0.0.0-dev_zookeeper-3.9.3_zookeeper-latest-3.9.3_number-of-datanodes-2_datanode-pvcs-2hdd-1ssd_listener-class-external-unstable_openshift-false: 2.5m

CONFIGURATION
----------------------------------------------
Parallel: 4
Parallel retry attempts: 1
Serial retry attempts: 1
Keep failed namespaces: True
Virtualenv: venv

Text report saved to: test-results/test_report.txt
Detailed JSON report saved to: test-results/detailed_report.json
```


## Definition of Done Checklist


### Author

- [x] Integration tests passed (for non trivial changes)

### Reviewer

- [ ] (Integration-)Test cases added
- [ ] Changelog updated

### Acceptance

- [ ] Proper release label has been added
