### PR TITLE
chore: Bump zookeeper version for 25.11.0

### DIFF
--- a/docs/modules/hdfs/examples/getting_started/zk.yaml
+++ b/docs/modules/hdfs/examples/getting_started/zk.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.3
+    productVersion: 3.9.4
   servers:
     roleGroups:
       default:

--- a/docs/modules/hdfs/examples/getting_started/zk.yaml.j2
+++ b/docs/modules/hdfs/examples/getting_started/zk.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.3
+    productVersion: 3.9.4
   servers:
     roleGroups:
       default:

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -16,9 +16,10 @@ dimensions:
   - name: zookeeper
     values:
       - 3.9.3
+      - 3.9.4
   - name: zookeeper-latest
     values:
-      - 3.9.3
+      - 3.9.4
   - name: krb5
     values:
       - 1.21.1


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/docker-images/issues/1275

### Integrationtests

```
--- PASS: kuttl (3889.43s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.1_zookeeper-3.9.4_zookeeper-latest-3.9.4_number-of-datanodes-1_datanode-pvcs-default_listener-class-external-unstable_openshift-false (211.76s)
        --- PASS: kuttl/harness/profiling_hadoop-3.4.1_zookeeper-latest-3.9.4_openshift-false (259.93s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.1_zookeeper-3.9.4_zookeeper-latest-3.9.4_number-of-datanodes-1_datanode-pvcs-default_listener-class-cluster-internal_openshift-false (168.12s)
        --- PASS: kuttl/harness/cluster-operation_hadoop-latest-3.4.1_zookeeper-latest-3.9.4_openshift-false (245.97s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.1_zookeeper-3.9.4_zookeeper-latest-3.9.4_number-of-datanodes-1_datanode-pvcs-2hdd-1ssd_listener-class-external-unstable_openshift-false (171.03s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.1_zookeeper-3.9.4_zookeeper-latest-3.9.4_number-of-datanodes-1_datanode-pvcs-2hdd-1ssd_listener-class-cluster-internal_openshift-false (163.80s)
        --- PASS: kuttl/harness/orphaned-resources_hadoop-latest-3.4.1_zookeeper-latest-3.9.4_openshift-false (182.69s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.1_zookeeper-3.9.4_zookeeper-latest-3.9.4_number-of-datanodes-2_datanode-pvcs-default_listener-class-external-unstable_openshift-false (246.80s)
        --- PASS: kuttl/harness/logging_hadoop-3.4.1_zookeeper-latest-3.9.4_openshift-false (711.90s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.1_zookeeper-3.9.4_zookeeper-latest-3.9.4_number-of-datanodes-2_datanode-pvcs-2hdd-1ssd_listener-class-external-unstable_openshift-false (231.75s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.1_zookeeper-3.9.4_zookeeper-latest-3.9.4_number-of-datanodes-2_datanode-pvcs-default_listener-class-cluster-internal_openshift-false (219.10s)
        --- PASS: kuttl/harness/topology-provider_hadoop-latest-3.4.1_zookeeper-latest-3.9.4_krb5-1.21.1_kerberos-backend-mit_openshift-false (347.42s)
        --- PASS: kuttl/harness/kerberos_hadoop-3.4.1_zookeeper-latest-3.9.4_krb5-1.21.1_opa-1.8.0_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_openshift-false (1392.33s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.1_zookeeper-3.9.4_zookeeper-latest-3.9.4_number-of-datanodes-2_datanode-pvcs-2hdd-1ssd_listener-class-cluster-internal_openshift-false (906.49s)
        --- PASS: kuttl/harness/kerberos_hadoop-3.4.1_zookeeper-latest-3.9.4_krb5-1.21.1_opa-1.8.0_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-false (1446.08s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
