### PR TITLE
fix: Revert/remove headless suffix from headless service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- BREAKING: Renamed headless rolegroup service from `<stacklet>-<role>-<rolegroup>` to `<stacklet>-<role>-<rolegroup>-headless` ([#721]).
-  - The `prometheus.io/scrape` label was moved to the metrics service
-  - The headless service now only exposes product / data ports, the metrics service only metrics ports
+- The `prometheus.io/scrape` label was moved to the metrics service ([#721]).
+- The headless service now only exposes product / data ports, the metrics service only metrics ports ([#721]).
 - Bump stackable-operator to `0.100.1` and product-config to `0.8.0` ([#722]).
 
 [#713]: https://github.com/stackabletech/hdfs-operator/pull/713

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,14 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - The `prometheus.io/scrape` label was moved to the metrics service ([#721]).
-- The headless service now only exposes product / data ports, the metrics service only metrics ports ([#721]).
+- The headless service now only exposes product / data ports, the metrics service only metrics ports ([#721], [#726]).
 - Bump stackable-operator to `0.100.1` and product-config to `0.8.0` ([#722]).
 
 [#713]: https://github.com/stackabletech/hdfs-operator/pull/713
 [#718]: https://github.com/stackabletech/hdfs-operator/pull/718
 [#721]: https://github.com/stackabletech/hdfs-operator/pull/721
 [#722]: https://github.com/stackabletech/hdfs-operator/pull/722
+[#726]: https://github.com/stackabletech/hdfs-operator/pull/726
 
 ## [25.7.0] - 2025-07-23
 

--- a/docs/modules/hdfs/examples/getting_started/getting_started.sh
+++ b/docs/modules/hdfs/examples/getting_started/getting_started.sh
@@ -116,7 +116,7 @@ kubectl rollout status --watch --timeout=5m statefulset/webhdfs
 
 file_status() {
   # tag::file-status[]
-  kubectl exec -n default webhdfs-0 -- curl -s -XGET "http://simple-hdfs-namenode-default-0.simple-hdfs-namenode-default-headless.default.svc.cluster.local:9870/webhdfs/v1/?op=LISTSTATUS"
+  kubectl exec -n default webhdfs-0 -- curl -s -XGET "http://simple-hdfs-namenode-default-0.simple-hdfs-namenode-default.default.svc.cluster.local:9870/webhdfs/v1/?op=LISTSTATUS"
   # end::file-status[]
 }
 
@@ -138,7 +138,7 @@ kubectl cp -n default ./testdata.txt webhdfs-0:/tmp
 create_file() {
   # tag::create-file[]
   kubectl exec -n default webhdfs-0 -- \
-  curl -s -XPUT -T /tmp/testdata.txt "http://simple-hdfs-namenode-default-0.simple-hdfs-namenode-default-headless.default.svc.cluster.local:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=CREATE&noredirect=true"
+  curl -s -XPUT -T /tmp/testdata.txt "http://simple-hdfs-namenode-default-0.simple-hdfs-namenode-default.default.svc.cluster.local:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=CREATE&noredirect=true"
   # end::create-file[]
 }
 
@@ -157,7 +157,7 @@ echo "Created file: $found_file with status $(file_status)"
 echo "Delete file"
 delete_file() {
   # tag::delete-file[]
-  kubectl exec -n default webhdfs-0 -- curl -s -XDELETE "http://simple-hdfs-namenode-default-0.simple-hdfs-namenode-default-headless.default.svc.cluster.local:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=DELETE"
+  kubectl exec -n default webhdfs-0 -- curl -s -XDELETE "http://simple-hdfs-namenode-default-0.simple-hdfs-namenode-default.default.svc.cluster.local:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=DELETE"
   # end::delete-file[]
 }
 

--- a/docs/modules/hdfs/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/hdfs/examples/getting_started/getting_started.sh.j2
@@ -116,7 +116,7 @@ kubectl rollout status --watch --timeout=5m statefulset/webhdfs
 
 file_status() {
   # tag::file-status[]
-  kubectl exec -n default webhdfs-0 -- curl -s -XGET "http://simple-hdfs-namenode-default-0.simple-hdfs-namenode-default-headless.default.svc.cluster.local:9870/webhdfs/v1/?op=LISTSTATUS"
+  kubectl exec -n default webhdfs-0 -- curl -s -XGET "http://simple-hdfs-namenode-default-0.simple-hdfs-namenode-default.default.svc.cluster.local:9870/webhdfs/v1/?op=LISTSTATUS"
   # end::file-status[]
 }
 
@@ -138,7 +138,7 @@ kubectl cp -n default ./testdata.txt webhdfs-0:/tmp
 create_file() {
   # tag::create-file[]
   kubectl exec -n default webhdfs-0 -- \
-  curl -s -XPUT -T /tmp/testdata.txt "http://simple-hdfs-namenode-default-0.simple-hdfs-namenode-default-headless.default.svc.cluster.local:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=CREATE&noredirect=true"
+  curl -s -XPUT -T /tmp/testdata.txt "http://simple-hdfs-namenode-default-0.simple-hdfs-namenode-default.default.svc.cluster.local:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=CREATE&noredirect=true"
   # end::create-file[]
 }
 
@@ -157,7 +157,7 @@ echo "Created file: $found_file with status $(file_status)"
 echo "Delete file"
 delete_file() {
   # tag::delete-file[]
-  kubectl exec -n default webhdfs-0 -- curl -s -XDELETE "http://simple-hdfs-namenode-default-0.simple-hdfs-namenode-default-headless.default.svc.cluster.local:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=DELETE"
+  kubectl exec -n default webhdfs-0 -- curl -s -XDELETE "http://simple-hdfs-namenode-default-0.simple-hdfs-namenode-default.default.svc.cluster.local:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=DELETE"
   # end::delete-file[]
 }
 

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -391,7 +391,7 @@ impl v1alpha1::HdfsCluster {
                 let ns = ns.clone();
                 (0..*replicas).map(move |i| HdfsPodRef {
                     namespace: ns.clone(),
-                    role_group_service_name: rolegroup_ref.rolegroup_headless_service_name(),
+                    role_group_service_name: rolegroup_ref.object_name(),
                     pod_name: format!("{}-{}", rolegroup_ref.object_name(), i),
                     ports: self
                         .data_ports(role)

--- a/rust/operator-binary/src/hdfs_controller.rs
+++ b/rust/operator-binary/src/hdfs_controller.rs
@@ -887,7 +887,7 @@ fn rolegroup_statefulset(
             match_labels: Some(rolegroup_selector_labels.into()),
             ..LabelSelector::default()
         },
-        service_name: Some(rolegroup_ref.rolegroup_headless_service_name()),
+        service_name: Some(rolegroup_ref.object_name()),
         template: pod_template,
 
         volume_claim_templates: Some(pvcs),

--- a/rust/operator-binary/src/service.rs
+++ b/rust/operator-binary/src/service.rs
@@ -48,7 +48,7 @@ pub(crate) fn rolegroup_headless_service(
     let mut metadata_builder = ObjectMetaBuilder::new();
     metadata_builder
         .name_and_namespace(hdfs)
-        .name(rolegroup_ref.rolegroup_headless_service_name())
+        .name(rolegroup_ref.object_name())
         .ownerreference_from_resource(hdfs, None, Some(true))
         .with_context(|_| ObjectMissingMetadataForOwnerRefSnafu {
             obj_ref: ObjectRef::from_obj(hdfs),

--- a/tests/templates/kuttl/orphaned-resources/04-assert.yaml
+++ b/tests/templates/kuttl/orphaned-resources/04-assert.yaml
@@ -21,4 +21,4 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: test-hdfs-datanode-newrolegroup-headless
+  name: test-hdfs-datanode-newrolegroup

--- a/tests/templates/kuttl/profiling/run-profiler.py
+++ b/tests/templates/kuttl/profiling/run-profiler.py
@@ -54,9 +54,7 @@ def fetch_flamegraph(service_url, refresh_path):
 
 
 def test_profiling(role, port):
-    service_url = (
-        f"http://test-hdfs-{role}-default-0.test-hdfs-{role}-default:{port}"
-    )
+    service_url = f"http://test-hdfs-{role}-default-0.test-hdfs-{role}-default:{port}"
 
     print(f"Test profiling on {service_url}")
 

--- a/tests/templates/kuttl/profiling/run-profiler.py
+++ b/tests/templates/kuttl/profiling/run-profiler.py
@@ -55,7 +55,7 @@ def fetch_flamegraph(service_url, refresh_path):
 
 def test_profiling(role, port):
     service_url = (
-        f"http://test-hdfs-{role}-default-0.test-hdfs-{role}-default-headless:{port}"
+        f"http://test-hdfs-{role}-default-0.test-hdfs-{role}-default:{port}"
     )
 
     print(f"Test profiling on {service_url}")

--- a/tests/templates/kuttl/smoke/30-assert.yaml.j2
+++ b/tests/templates/kuttl/smoke/30-assert.yaml.j2
@@ -80,7 +80,7 @@ status:
 apiVersion: v1
 kind: Service
 metadata:
-  name: hdfs-namenode-default-headless
+  name: hdfs-namenode-default
 spec:
   ports:
   - name: rpc
@@ -110,7 +110,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: hdfs-datanode-default-headless
+  name: hdfs-datanode-default
 spec:
   ports:
   - name: data
@@ -144,7 +144,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: hdfs-journalnode-default-headless
+  name: hdfs-journalnode-default
 spec:
   ports:
   - name: rpc

--- a/tests/templates/kuttl/smoke/test_jmx_metrics.py
+++ b/tests/templates/kuttl/smoke/test_jmx_metrics.py
@@ -65,9 +65,9 @@ def check_datanode_metrics(
         # Kind "FSDatasetState"
         'hadoop_datanode_capacity{fsdatasetid=".+",kind="FSDatasetState",role="DataNode",service="HDFS"}',
         # Kind "DataNodeActivity" suffixed with "_info"
-        'hadoop_datanode_blocks_get_local_path_info_{host="hdfs-datanode-default-\\d+\\.hdfs-datanode-default-headless\\..+\\.svc\\.cluster\\.local",kind="DataNodeActivity",port="9866",role="DataNode",service="HDFS"}',
+        'hadoop_datanode_blocks_get_local_path_info_{host="hdfs-datanode-default-\\d+\\.hdfs-datanode-default\\..+\\.svc\\.cluster\\.local",kind="DataNodeActivity",port="9866",role="DataNode",service="HDFS"}',
         # Kind "DataNodeActivity"
-        'hadoop_datanode_blocks_read{host="hdfs-datanode-default-\\d+\\.hdfs-datanode-default-headless\\..+\\.svc\\.cluster\\.local",kind="DataNodeActivity",port="9866",role="DataNode",service="HDFS"}',
+        'hadoop_datanode_blocks_read{host="hdfs-datanode-default-\\d+\\.hdfs-datanode-default\\..+\\.svc\\.cluster\\.local",kind="DataNodeActivity",port="9866",role="DataNode",service="HDFS"}',
         # Counter suffixed with "_total"
         'hadoop_datanode_estimated_capacity_lost_total{kind="FSDatasetState",role="DataNode",service="HDFS"}',
         # Boolean metric

--- a/tests/templates/kuttl/smoke/webhdfs.py
+++ b/tests/templates/kuttl/smoke/webhdfs.py
@@ -17,7 +17,7 @@ def main() -> int:
 
     if command == "ls":
         http_code = requests.get(
-            f"http://hdfs-namenode-default-0.hdfs-namenode-default-headless.{namespace}.svc.cluster.local:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=LISTSTATUS"
+            f"http://hdfs-namenode-default-0.hdfs-namenode-default.{namespace}.svc.cluster.local:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=LISTSTATUS"
         ).status_code
         if http_code != 200:
             result = 1
@@ -31,7 +31,7 @@ def main() -> int:
             )
         }
         http_code = requests.put(
-            f"http://hdfs-namenode-default-0.hdfs-namenode-default-headless.{namespace}.svc.cluster.local:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=CREATE",
+            f"http://hdfs-namenode-default-0.hdfs-namenode-default.{namespace}.svc.cluster.local:9870/webhdfs/v1/testdata.txt?user.name=stackable&op=CREATE",
             files=files,
             allow_redirects=True,
         ).status_code


### PR DESCRIPTION
## Description

- Revert the `<stacklet>-<role>-<rolegroup>` to `<stacklet>-<role>-<rolegroup>-headless` change.
- The headless service now does not contain the -headless suffix anymore which made problems during upgrading in zookeeper. See https://stackable-workspace.slack.com/archives/C031A56R127/p1762175152171189 for details

```
2025-11-03 13:03:58,809 INFO  ha.ActiveStandbyElector (ActiveStandbyElector.java:processWatchEvent(649)) - Session connected.
2025-11-03 13:03:58,810 INFO  ha.ActiveStandbyElector (ActiveStandbyElector.java:fenceOldActive(1019)) - Checking for any old active which needs to be fenced...
2025-11-03 13:03:58,811 INFO  ha.ActiveStandbyElector (ActiveStandbyElector.java:fenceOldActive(1040)) - Old node exists: 0a04686466731217686466732d6e616d656e6f64652d64656661756c742d301a47686466732d6e616d656e6f64652d64656661756c742d302e686466732d6e616d656e6f64652d64656661756c742e64656661756c742e7376632e636c75737465722e6c6f63616c20d43e28d33e
2025-11-03 13:03:58,812 WARN  ha.ActiveStandbyElector (ActiveStandbyElector.java:becomeActive(952)) - Exception handling the winning of election
java.lang.RuntimeException: Mismatched address stored in ZK for NameNode at hdfs-namenode-default-0.hdfs-namenode-default-headless.default.svc.cluster.local/100.97.191.176:8020: Stored protobuf was nameserviceId: "hdfs"
namenodeId: "hdfs-namenode-default-0"
hostname: "hdfs-namenode-default-0.hdfs-namenode-default.default.svc.cluster.local"
port: 8020
zkfcPort: 8019
, address from our own configuration for this NameNode was hdfs-namenode-default-0.hdfs-namenode-default-headless.default.svc.cluster.local/100.97.191.176:8020
        at org.apache.hadoop.hdfs.tools.DFSZKFailoverController.dataToTarget(DFSZKFailoverController.java:91)
        at org.apache.hadoop.ha.ZKFailoverController.fenceOldActive(ZKFailoverController.java:533)
        at org.apache.hadoop.ha.ZKFailoverController.access$1100(ZKFailoverController.java:65)
        at org.apache.hadoop.ha.ZKFailoverController$ElectorCallbacks.fenceOldActive(ZKFailoverController.java:973)
        at org.apache.hadoop.ha.ActiveStandbyElector.fenceOldActive(ActiveStandbyElector.java:1044)
        at org.apache.hadoop.ha.ActiveStandbyElector.becomeActive(ActiveStandbyElector.java:943)
        at org.apache.hadoop.ha.ActiveStandbyElector.processResult(ActiveStandbyElector.java:509)
        at org.apache.zookeeper.ClientCnxn$EventThread.processEvent(ClientCnxn.java:675)
        at org.apache.zookeeper.ClientCnxn$EventThread.run(ClientCnxn.java:554)
2025-11-03 13:03:58,812 INFO  ha.ActiveStandbyElector (ActiveStandbyElector.java:reJoinElection(799)) - Trying to re-establish ZK session
2025-11-03 13:03:58,916 INFO  zookeeper.ZooKeeper (ZooKeeper.java:close(1232)) - Session: 0x100088e24760797 closed
2025-11-03 13:03:59,917 INFO  zookeeper.ZooKeeper (ZooKeeper.java:<init>(637)) - Initiating client connection, connectString=zookeeper-server.default.svc.cluster.local:2282/znode-2aa300aa-3042-43ca-8076-4a224c72dea6 sessionTimeout=10000 watcher=org.apache.hadoop.ha.ActiveStandbyElector$WatcherWithClientRef@6cdbb1a5
2025-11-03 13:03:59,917 INFO  zookeeper.ClientCnxnSocket (ClientCnxnSocket.java:initProperties(239)) - jute.maxbuffer value is 1048575 Bytes
2025-11-03 13:03:59,917 INFO  zookeeper.ClientCnxn (ClientCnxn.java:initRequestTimeout(1747)) - zookeeper.request.timeout value is 0. feature enabled=false
2025-11-03 13:03:59,917 INFO  zookeeper.ClientCnxn (ClientCnxn.java:logStartConnect(1177)) - Opening socket connection to server zookeeper-server.default.svc.cluster.local/100.64.47.126:2282.
2025-11-03 13:03:59,918 INFO  zookeeper.ClientCnxn (ClientCnxn.java:logStartConnect(1179)) - SASL config status: Will not attempt to authenticate using SASL (unknown error)
2025-11-03 13:03:59,918 INFO  zookeeper.ClientCnxn (ClientCnxn.java:primeConnection(1013)) - Socket connection established, initiating session, client: /100.97.191.176:34248, server: zookeeper-server.default.svc.cluster.local/100.64.47.126:2282
2025-11-03 13:03:59,926 INFO  zookeeper.ClientCnxn (ClientCnxn.java:onConnected(1453)) - Session establishment complete on server zookeeper-server.default.svc.cluster.local/100.64.47.126:2282, session id = 0x100088e24760799, negotiated timeout = 10000
2025-11-03 13:03:59,926 WARN  ha.ActiveStandbyElector (ActiveStandbyElector.java:isStaleClient(1176)) - Ignoring stale result from old client with sessionId 0x100088e24760797
2025-11-03 13:03:59,926 INFO  zookeeper.ClientCnxn (ClientCnxn.java:run(569)) - EventThread shut down for session: 0x100088e24760797
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
