### PR TITLE
chore: use new testing-tools image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,14 @@ All notable changes to this project will be documented in this file.
 - The `prometheus.io/scrape` label was moved to the metrics service ([#721]).
 - The headless service now only exposes product / data ports, the metrics service only metrics ports ([#721], [#726]).
 - Bump stackable-operator to `0.100.1` and product-config to `0.8.0` ([#722]).
+- Bump testing-tools to `0.3.0-stackable0.0.0-dev` ([#740]).
 
 [#713]: https://github.com/stackabletech/hdfs-operator/pull/713
 [#718]: https://github.com/stackabletech/hdfs-operator/pull/718
 [#721]: https://github.com/stackabletech/hdfs-operator/pull/721
 [#722]: https://github.com/stackabletech/hdfs-operator/pull/722
 [#726]: https://github.com/stackabletech/hdfs-operator/pull/726
+[#740]: https://github.com/stackabletech/hdfs-operator/pull/740
 
 ## [25.7.0] - 2025-07-23
 

--- a/docs/modules/hdfs/examples/getting_started/webhdfs.yaml
+++ b/docs/modules/hdfs/examples/getting_started/webhdfs.yaml
@@ -18,6 +18,6 @@ spec:
     spec:
       containers:
         - name: webhdfs
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
           stdin: true
           tty: true

--- a/tests/templates/kuttl/logging/06-install-hdfs-test-runner.yaml
+++ b/tests/templates/kuttl/logging/06-install-hdfs-test-runner.yaml
@@ -18,7 +18,7 @@ spec:
       shareProcessNamespace: true
       containers:
         - name: hdfs-test-runner
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
           args: [sleep, infinity]
           stdin: true
           tty: true

--- a/tests/templates/kuttl/profiling/04-install-test-container.yaml
+++ b/tests/templates/kuttl/profiling/04-install-test-container.yaml
@@ -26,7 +26,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: python
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
           stdin: true
           tty: true
           resources:

--- a/tests/templates/kuttl/smoke/40-install-test-runner.yaml
+++ b/tests/templates/kuttl/smoke/40-install-test-runner.yaml
@@ -18,7 +18,7 @@ spec:
       shareProcessNamespace: true
       containers:
         - name: test-runner
-          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.3.0-stackable0.0.0-dev
           args: [sleep, infinity]
           stdin: true
           tty: true


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/767

This uses the new oci.stackable.tech/sdp/testing-tools image (0.3.0).

Ran some tests to verify they still work:

--- PASS: kuttl (246.86s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_hadoop-3.4.2_zookeeper-3.9.4_zookeeper-latest-3.9.4_number-of-datanodes-2_datanode-pvcs-2hdd-1ssd_listener-class-external-unstable_openshift-false (246.85s)

--- PASS: kuttl (668.30s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/logging_hadoop-3.4.2_zookeeper-latest-3.9.4_openshift-false (668.29s)

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
