### PR TITLE
test: Bump vector 0.52.0 and opa 1.12.2

### DIFF
--- a/tests/templates/kuttl/logging/01-install-hdfs-vector-aggregator.yaml
+++ b/tests/templates/kuttl/logging/01-install-hdfs-vector-aggregator.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install hdfs-vector-aggregator vector
       --namespace $NAMESPACE
-      --version 0.45.0
+      --version 0.49.0
       --repo https://helm.vector.dev
       --values hdfs-vector-aggregator-values.yaml
 ---

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -25,7 +25,7 @@ dimensions:
       - 1.21.1
   - name: opa
     values:
-      - 1.8.0
+      - 1.12.2
   - name: number-of-datanodes
     values:
       - "1"


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/docker-images/issues/1378
Part of https://github.com/stackabletech/docker-images/issues/1369

- test: Bump OPA to 1.12.2
- test: Bump vector to 0.52.0 (chart version 0.49.0).
