### PR TITLE
test: Remove ZooKeeper 3.9.3

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -15,7 +15,6 @@ dimensions:
       - 3.4.2
   - name: zookeeper
     values:
-      - 3.9.3
       - 3.9.4
   - name: zookeeper-latest
     values:


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1384

remove ZooKeeper 3.9.3 from tests