### PR TITLE
docs: Remove 3.4.1 from supported versions

### DIFF
--- a/docs/modules/hdfs/partials/supported-versions.adoc
+++ b/docs/modules/hdfs/partials/supported-versions.adoc
@@ -3,4 +3,3 @@
 // Stackable Platform documentation.
 
 - 3.4.2 (LTS)
-- 3.4.1 (Deprecated)


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1374