### PR TITLE
Improve shell capturing in init containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Previosly, some shell output of init-containers was not logged properly and therefore not aggregated, which is fixed now ([#746]).
+- Previously, some shell output of init-containers was not logged properly and therefore not aggregated, which is fixed now ([#746]).
 
 [#741]: https://github.com/stackabletech/hdfs-operator/pull/741
 [#743]: https://github.com/stackabletech/hdfs-operator/pull/743

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,13 @@ All notable changes to this project will be documented in this file.
   See [objectOverrides concepts page](https://docs.stackable.tech/home/nightly/concepts/overrides/#object-overrides) for details ([#741]).
 - Enable the [restart-controller](https://docs.stackable.tech/home/nightly/commons-operator/restarter/), so that the Pods are automatically restarted on config changes ([#743]).
 
+### Fixed
+
+- Previosly, some shell output of init-containers was not logged properly and therefore not aggregated, which is fixed now ([#746]).
+
 [#741]: https://github.com/stackabletech/hdfs-operator/pull/741
 [#743]: https://github.com/stackabletech/hdfs-operator/pull/743
+[#746]: https://github.com/stackabletech/hdfs-operator/pull/746
 
 ## [25.11.0] - 2025-11-07
 

--- a/rust/operator-binary/src/container.rs
+++ b/rust/operator-binary/src/container.rs
@@ -693,7 +693,7 @@ impl ContainerConfig {
                     do
                       echo -n "Checking pod $namenode_id... "
 
-                      # We only redirect 2 (stderr) to 4 (console). 
+                      # We only redirect 2 (stderr) to 4 (console).
                       # We leave 1 (stdout) alone so the $(...) can catch it.
                       SERVICE_STATE=$({hadoop_home}/bin/hdfs haadmin -getServiceState "$namenode_id" 2>&4 | tail -n1 || true)
                       
@@ -703,7 +703,7 @@ impl ContainerConfig {
                         echo "active"
                         break
                       else
-                        echo "unknown / unreachable"  
+                        echo "unknown / unreachable"
                       fi
                     done
 
@@ -792,7 +792,7 @@ impl ContainerConfig {
                       do
                         echo -n "Checking pod $namenode_id... "
 
-                        # We only redirect 2 (stderr) to 4 (console). 
+                        # We only redirect 2 (stderr) to 4 (console).
                         # We leave 1 (stdout) alone so the $(...) can catch it.
                         SERVICE_STATE=$({hadoop_home}/bin/hdfs haadmin -getServiceState "$namenode_id" 2>&4 | tail -n1 || true)
 
@@ -1604,7 +1604,7 @@ fn bash_capture_shell_helper(container_name: &str) -> String {
             "$@" 1>&3 2>&4
             local exit_code=$?
             set -e
-            
+
             # If the command failed, we manually trigger the exit since we set +e
             if [ $exit_code -ne 0 ]; then
                 exit $exit_code

--- a/rust/operator-binary/src/container.rs
+++ b/rust/operator-binary/src/container.rs
@@ -1597,9 +1597,7 @@ fn bash_capture_shell_helper(container_name: &str) -> String {
             # Temporarily restore original FDs just for the duration of this command
             # We use 'local' for the exit code to keep things clean
             "$@" 1>&3 2>&4
-            local exit_code=$?
-
-            echo $exit_code
+            echo $?
         }}
 
         start_capture

--- a/rust/operator-binary/src/container.rs
+++ b/rust/operator-binary/src/container.rs
@@ -666,7 +666,6 @@ impl ContainerConfig {
             }
             ContainerConfig::FormatNameNodes { container_name, .. } => {
                 args.push_str(&bash_capture_shell_helper(container_name));
-                args.push_str("start_capture\n");
 
                 if let Some(container_config) = merged_config.as_namenode().map(|node| {
                     node.logging
@@ -733,7 +732,6 @@ impl ContainerConfig {
             }
             ContainerConfig::FormatZooKeeper { container_name, .. } => {
                 args.push_str(&bash_capture_shell_helper(container_name));
-                args.push_str("start_capture\n");
 
                 if let Some(container_config) = merged_config.as_namenode().map(|node| {
                     node.logging
@@ -770,7 +768,6 @@ impl ContainerConfig {
             }
             ContainerConfig::WaitForNameNodes { container_name, .. } => {
                 args.push_str(&bash_capture_shell_helper(container_name));
-                args.push_str("start_capture\n");
 
                 if let Some(container_config) = merged_config.as_datanode().map(|node| {
                     node.logging
@@ -794,7 +791,7 @@ impl ContainerConfig {
                       for namenode_id in {pod_names}
                       do
                         echo -n "Checking pod $namenode_id... "
-                        
+
                         # We only redirect 2 (stderr) to 4 (console). 
                         # We leave 1 (stdout) alone so the $(...) can catch it.
                         SERVICE_STATE=$({hadoop_home}/bin/hdfs haadmin -getServiceState "$namenode_id" 2>&4 | tail -n1 || true)
@@ -1613,6 +1610,8 @@ fn bash_capture_shell_helper(container_name: &str) -> String {
                 exit $exit_code
             fi
         }}
+
+        start_capture
         "###
     }
 }

--- a/rust/operator-binary/src/container.rs
+++ b/rust/operator-binary/src/container.rs
@@ -746,10 +746,8 @@ impl ContainerConfig {
                     r###"
                     echo "Attempt to format ZooKeeper..."
                     if [[ "0" -eq "$(echo $POD_NAME | sed -e 's/.*-//')" ]] ; then
-                      set +e
                       exclude_from_capture {hadoop_home}/bin/hdfs zkfc -formatZK -nonInteractive
                       EXITCODE=$?
-                      set -e
                       if [[ $EXITCODE -eq 0 ]]; then
                         echo "Successfully formatted"
                       elif [[ $EXITCODE -eq 2 ]]; then

--- a/rust/operator-binary/src/container.rs
+++ b/rust/operator-binary/src/container.rs
@@ -696,7 +696,7 @@ impl ContainerConfig {
                       # We only redirect 2 (stderr) to 4 (console).
                       # We leave 1 (stdout) alone so the $(...) can catch it.
                       SERVICE_STATE=$({hadoop_home}/bin/hdfs haadmin -getServiceState "$namenode_id" 2>&4 | tail -n1 || true)
-                      
+
                       if [ "$SERVICE_STATE" == "active" ]
                       then
                         ACTIVE_NAMENODE="$namenode_id"

--- a/tests/templates/kuttl/logging/hdfs-vector-aggregator-values.yaml.j2
+++ b/tests/templates/kuttl/logging/hdfs-vector-aggregator-values.yaml.j2
@@ -123,6 +123,20 @@ customConfig:
         .pod == "test-hdfs-automatic-log-namenode-default-0" &&
         .container == "format-zookeeper" &&
         .file == "container.stderr.log"
+    filteredAutomaticLogConfigNameNode1FormatZookeeperStdout:
+      type: filter
+      inputs: [validEvents]
+      condition: >-
+        .pod == "test-hdfs-automatic-log-namenode-default-1" &&
+        .container == "format-zookeeper" &&
+        .file == "container.stdout.log"
+    filteredAutomaticLogConfigNameNode1FormatZookeeperStderr:
+      type: filter
+      inputs: [validEvents]
+      condition: >-
+        .pod == "test-hdfs-automatic-log-namenode-default-1" &&
+        .container == "format-zookeeper" &&
+        .file == "container.stderr.log"
     filteredAutomaticLogConfigDataNode0:
       type: filter
       inputs: [validEvents]
@@ -135,12 +149,27 @@ customConfig:
       condition: >-
         .pod == "test-hdfs-automatic-log-datanode-default-0" &&
         .container == "vector"
-    filteredAutomaticLogConfigDataNode0WaitForNameNodes:
+    filteredAutomaticLogConfigDataNode0WaitForNameNodesLog4j:
       type: filter
       inputs: [validEvents]
       condition: >-
         .pod == "test-hdfs-automatic-log-datanode-default-0" &&
-        .container == "wait-for-namenodes"
+        .container == "wait-for-namenodes" &&
+        .file == "wait-for-namenodes.log4j.xml"
+    filteredAutomaticLogConfigDataNode0WaitForNameNodesStdout:
+      type: filter
+      inputs: [validEvents]
+      condition: >-
+        .pod == "test-hdfs-automatic-log-datanode-default-0" &&
+        .container == "wait-for-namenodes" &&
+        .file == "container.stdout.log"
+    filteredAutomaticLogConfigDataNode0WaitForNameNodesStderr:
+      type: filter
+      inputs: [validEvents]
+      condition: >-
+        .pod == "test-hdfs-automatic-log-datanode-default-0" &&
+        .container == "wait-for-namenodes" &&
+        .file == "container.stderr.log"
     filteredAutomaticLogConfigJournalNode0:
       type: filter
       inputs: [validEvents]

--- a/tests/templates/kuttl/logging/hdfs-vector-aggregator-values.yaml.j2
+++ b/tests/templates/kuttl/logging/hdfs-vector-aggregator-values.yaml.j2
@@ -60,18 +60,48 @@ customConfig:
       condition: >-
         .pod == "test-hdfs-automatic-log-namenode-default-1" &&
         .container == "vector"
-    filteredAutomaticLogConfigNameNode0FormatNameNode:
+    filteredAutomaticLogConfigNameNode0FormatNameNodeLog4j:
       type: filter
       inputs: [validEvents]
       condition: >-
         .pod == "test-hdfs-automatic-log-namenode-default-0" &&
-        .container == "format-namenodes"
-    filteredAutomaticLogConfigNameNode1FormatNameNode:
+        .container == "format-namenodes" &&
+        .file == "format-namenodes.log4j.xml"
+    filteredAutomaticLogConfigNameNode0FormatNameNodeStdout:
+      type: filter
+      inputs: [validEvents]
+      condition: >-
+        .pod == "test-hdfs-automatic-log-namenode-default-0" &&
+        .container == "format-namenodes" &&
+        .file == "container.stdout.log"
+    filteredAutomaticLogConfigNameNode0FormatNameNodeStderr:
+      type: filter
+      inputs: [validEvents]
+      condition: >-
+        .pod == "test-hdfs-automatic-log-namenode-default-0" &&
+        .container == "format-namenodes" &&
+        .file == "container.stderr.log"
+    filteredAutomaticLogConfigNameNode1FormatNameNodeLog4j:
       type: filter
       inputs: [validEvents]
       condition: >-
         .pod == "test-hdfs-automatic-log-namenode-default-1" &&
-        .container == "format-namenodes"
+        .container == "format-namenodes" &&
+        .file == "format-namenodes.log4j.xml"
+    filteredAutomaticLogConfigNameNode1FormatNameNodeStdout:
+      type: filter
+      inputs: [validEvents]
+      condition: >-
+        .pod == "test-hdfs-automatic-log-namenode-default-1" &&
+        .container == "format-namenodes" &&
+        .file == "container.stdout.log"
+    filteredAutomaticLogConfigNameNode1FormatNameNodeStderr:
+      type: filter
+      inputs: [validEvents]
+      condition: >-
+        .pod == "test-hdfs-automatic-log-namenode-default-1" &&
+        .container == "format-namenodes" &&
+        .file == "container.stderr.log"
     filteredAutomaticLogConfigNameNode0FormatZookeeper:
       type: filter
       inputs: [validEvents]

--- a/tests/templates/kuttl/logging/hdfs-vector-aggregator-values.yaml.j2
+++ b/tests/templates/kuttl/logging/hdfs-vector-aggregator-values.yaml.j2
@@ -102,12 +102,27 @@ customConfig:
         .pod == "test-hdfs-automatic-log-namenode-default-1" &&
         .container == "format-namenodes" &&
         .file == "container.stderr.log"
-    filteredAutomaticLogConfigNameNode0FormatZookeeper:
+    filteredAutomaticLogConfigNameNode0FormatZookeeperLog4j:
       type: filter
       inputs: [validEvents]
       condition: >-
         .pod == "test-hdfs-automatic-log-namenode-default-0" &&
-        .container == "format-zookeeper"
+        .container == "format-zookeeper" &&
+        .file == "format-zookeeper.log4j.xml"
+    filteredAutomaticLogConfigNameNode0FormatZookeeperStdout:
+      type: filter
+      inputs: [validEvents]
+      condition: >-
+        .pod == "test-hdfs-automatic-log-namenode-default-0" &&
+        .container == "format-zookeeper" &&
+        .file == "container.stdout.log"
+    filteredAutomaticLogConfigNameNode0FormatZookeeperStderr:
+      type: filter
+      inputs: [validEvents]
+      condition: >-
+        .pod == "test-hdfs-automatic-log-namenode-default-0" &&
+        .container == "format-zookeeper" &&
+        .file == "container.stderr.log"
     filteredAutomaticLogConfigDataNode0:
       type: filter
       inputs: [validEvents]


### PR DESCRIPTION
## Description

We have some integration test failures in products using HDFS, where the format image somehow fails. 

```
Failed to start namenode.\njava.io.FileNotFoundException: No valid image files found
```

and 

```
Failed to start namenode.\norg.apache.hadoop.hdfs.qjournal.client.QuorumException: Could not format one or more JournalNodes. 1 exceptions thrown:\n10.42.11.24:8485: End of File Exception between local host is: \"hdfs-namenode-default-0/10.42.11.25\"; destination host is: \"hdfs-journalnode-default-0.hdfs-journalnode-default.kuttl-test-calm-hookworm.svc.cluster.local\":8485; : java.io.EOFException; For more details see:  http://wiki.apache.org/hadoop/EOFException
```

We previously did not catch the init container shell output properly, which is done in this PR.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [x] Code contains useful comments
- [x] Changelog updated

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
