### PR TITLE
test: Bump OPA to 1.12.3

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -24,7 +24,7 @@ dimensions:
       - 1.21.1
   - name: opa
     values:
-      - 1.12.2
+      - 1.12.3
   - name: number-of-datanodes
     values:
       - "1"


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1418

> [!NOTE]
> I didn't add a changelog entry since it was effectively just tests, and the previous bump wasn't recorded.

Test results:

```
--- PASS: kuttl (2624.69s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/kerberos_hadoop-3.4.2_zookeeper-latest-3.9.4_krb5-1.21.1_opa-1.12.3_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_openshift-false (1272.11s)
        --- PASS: kuttl/harness/kerberos_hadoop-3.4.2_zookeeper-latest-3.9.4_krb5-1.21.1_opa-1.12.3_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-false (1352.56s)
PASS
```