### PR TITLE
Use KeyValueConfigOverrides with `BTreeMap<String, String>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "k8s-version"
 version = "0.1.3"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#de69410331ea51a37ec91e511d0d2f33056b6032"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#c366edd287d177cd8d69fe3351bf0cc797ef2e4c"
 dependencies = [
  "darling",
  "regex",
@@ -2893,7 +2893,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stackable-certs"
 version = "0.4.0"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#de69410331ea51a37ec91e511d0d2f33056b6032"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#c366edd287d177cd8d69fe3351bf0cc797ef2e4c"
 dependencies = [
  "const-oid",
  "ecdsa",
@@ -2939,7 +2939,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator"
 version = "0.111.1"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#de69410331ea51a37ec91e511d0d2f33056b6032"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#c366edd287d177cd8d69fe3351bf0cc797ef2e4c"
 dependencies = [
  "base64",
  "clap",
@@ -2983,7 +2983,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#de69410331ea51a37ec91e511d0d2f33056b6032"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#c366edd287d177cd8d69fe3351bf0cc797ef2e4c"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2994,7 +2994,7 @@ dependencies = [
 [[package]]
 name = "stackable-shared"
 version = "0.1.1"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#de69410331ea51a37ec91e511d0d2f33056b6032"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#c366edd287d177cd8d69fe3351bf0cc797ef2e4c"
 dependencies = [
  "jiff",
  "k8s-openapi",
@@ -3011,7 +3011,7 @@ dependencies = [
 [[package]]
 name = "stackable-telemetry"
 version = "0.6.4"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#de69410331ea51a37ec91e511d0d2f33056b6032"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#c366edd287d177cd8d69fe3351bf0cc797ef2e4c"
 dependencies = [
  "axum",
  "clap",
@@ -3035,7 +3035,7 @@ dependencies = [
 [[package]]
 name = "stackable-versioned"
 version = "0.10.0"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#de69410331ea51a37ec91e511d0d2f33056b6032"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#c366edd287d177cd8d69fe3351bf0cc797ef2e4c"
 dependencies = [
  "kube",
  "schemars",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "stackable-versioned-macros"
 version = "0.10.0"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#de69410331ea51a37ec91e511d0d2f33056b6032"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#c366edd287d177cd8d69fe3351bf0cc797ef2e4c"
 dependencies = [
  "convert_case",
  "convert_case_extras",
@@ -3067,7 +3067,7 @@ dependencies = [
 [[package]]
 name = "stackable-webhook"
 version = "0.9.1"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#de69410331ea51a37ec91e511d0d2f33056b6032"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#c366edd287d177cd8d69fe3351bf0cc797ef2e4c"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "k8s-version"
 version = "0.1.3"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#c366edd287d177cd8d69fe3351bf0cc797ef2e4c"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#451088f77acee6c3d296754698260256c250ecb2"
 dependencies = [
  "darling",
  "regex",
@@ -2893,7 +2893,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stackable-certs"
 version = "0.4.0"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#c366edd287d177cd8d69fe3351bf0cc797ef2e4c"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#451088f77acee6c3d296754698260256c250ecb2"
 dependencies = [
  "const-oid",
  "ecdsa",
@@ -2939,7 +2939,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator"
 version = "0.111.1"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#c366edd287d177cd8d69fe3351bf0cc797ef2e4c"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#451088f77acee6c3d296754698260256c250ecb2"
 dependencies = [
  "base64",
  "clap",
@@ -2983,7 +2983,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#c366edd287d177cd8d69fe3351bf0cc797ef2e4c"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#451088f77acee6c3d296754698260256c250ecb2"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2994,7 +2994,7 @@ dependencies = [
 [[package]]
 name = "stackable-shared"
 version = "0.1.1"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#c366edd287d177cd8d69fe3351bf0cc797ef2e4c"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#451088f77acee6c3d296754698260256c250ecb2"
 dependencies = [
  "jiff",
  "k8s-openapi",
@@ -3011,7 +3011,7 @@ dependencies = [
 [[package]]
 name = "stackable-telemetry"
 version = "0.6.4"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#c366edd287d177cd8d69fe3351bf0cc797ef2e4c"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#451088f77acee6c3d296754698260256c250ecb2"
 dependencies = [
  "axum",
  "clap",
@@ -3035,7 +3035,7 @@ dependencies = [
 [[package]]
 name = "stackable-versioned"
 version = "0.10.0"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#c366edd287d177cd8d69fe3351bf0cc797ef2e4c"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#451088f77acee6c3d296754698260256c250ecb2"
 dependencies = [
  "kube",
  "schemars",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "stackable-versioned-macros"
 version = "0.10.0"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#c366edd287d177cd8d69fe3351bf0cc797ef2e4c"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#451088f77acee6c3d296754698260256c250ecb2"
 dependencies = [
  "convert_case",
  "convert_case_extras",
@@ -3067,7 +3067,7 @@ dependencies = [
 [[package]]
 name = "stackable-webhook"
 version = "0.9.1"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#c366edd287d177cd8d69fe3351bf0cc797ef2e4c"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#451088f77acee6c3d296754698260256c250ecb2"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -4826,8 +4826,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "de69410331ea51a37ec91e511d0d2f33056b6032";
-          sha256 = "0idpq1xdkr94zrd95xsvrwkj3bvzbii9a7qmw23rn5w4yiwgmj96";
+          rev = "c366edd287d177cd8d69fe3351bf0cc797ef2e4c";
+          sha256 = "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb";
         };
         libName = "k8s_version";
         authors = [
@@ -9509,8 +9509,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "de69410331ea51a37ec91e511d0d2f33056b6032";
-          sha256 = "0idpq1xdkr94zrd95xsvrwkj3bvzbii9a7qmw23rn5w4yiwgmj96";
+          rev = "c366edd287d177cd8d69fe3351bf0cc797ef2e4c";
+          sha256 = "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb";
         };
         libName = "stackable_certs";
         authors = [
@@ -9706,8 +9706,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "de69410331ea51a37ec91e511d0d2f33056b6032";
-          sha256 = "0idpq1xdkr94zrd95xsvrwkj3bvzbii9a7qmw23rn5w4yiwgmj96";
+          rev = "c366edd287d177cd8d69fe3351bf0cc797ef2e4c";
+          sha256 = "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb";
         };
         libName = "stackable_operator";
         authors = [
@@ -9900,8 +9900,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "de69410331ea51a37ec91e511d0d2f33056b6032";
-          sha256 = "0idpq1xdkr94zrd95xsvrwkj3bvzbii9a7qmw23rn5w4yiwgmj96";
+          rev = "c366edd287d177cd8d69fe3351bf0cc797ef2e4c";
+          sha256 = "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb";
         };
         procMacro = true;
         libName = "stackable_operator_derive";
@@ -9935,8 +9935,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "de69410331ea51a37ec91e511d0d2f33056b6032";
-          sha256 = "0idpq1xdkr94zrd95xsvrwkj3bvzbii9a7qmw23rn5w4yiwgmj96";
+          rev = "c366edd287d177cd8d69fe3351bf0cc797ef2e4c";
+          sha256 = "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb";
         };
         libName = "stackable_shared";
         authors = [
@@ -10016,8 +10016,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "de69410331ea51a37ec91e511d0d2f33056b6032";
-          sha256 = "0idpq1xdkr94zrd95xsvrwkj3bvzbii9a7qmw23rn5w4yiwgmj96";
+          rev = "c366edd287d177cd8d69fe3351bf0cc797ef2e4c";
+          sha256 = "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb";
         };
         libName = "stackable_telemetry";
         authors = [
@@ -10126,8 +10126,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "de69410331ea51a37ec91e511d0d2f33056b6032";
-          sha256 = "0idpq1xdkr94zrd95xsvrwkj3bvzbii9a7qmw23rn5w4yiwgmj96";
+          rev = "c366edd287d177cd8d69fe3351bf0cc797ef2e4c";
+          sha256 = "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb";
         };
         libName = "stackable_versioned";
         authors = [
@@ -10176,8 +10176,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "de69410331ea51a37ec91e511d0d2f33056b6032";
-          sha256 = "0idpq1xdkr94zrd95xsvrwkj3bvzbii9a7qmw23rn5w4yiwgmj96";
+          rev = "c366edd287d177cd8d69fe3351bf0cc797ef2e4c";
+          sha256 = "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb";
         };
         procMacro = true;
         libName = "stackable_versioned_macros";
@@ -10244,8 +10244,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "de69410331ea51a37ec91e511d0d2f33056b6032";
-          sha256 = "0idpq1xdkr94zrd95xsvrwkj3bvzbii9a7qmw23rn5w4yiwgmj96";
+          rev = "c366edd287d177cd8d69fe3351bf0cc797ef2e4c";
+          sha256 = "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb";
         };
         libName = "stackable_webhook";
         authors = [

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -4826,8 +4826,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "c366edd287d177cd8d69fe3351bf0cc797ef2e4c";
-          sha256 = "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb";
+          rev = "451088f77acee6c3d296754698260256c250ecb2";
+          sha256 = "1ifdpn0jvrf3xbgqldqxrq9ig1dc34d4fip7qxn38526k8004p4b";
         };
         libName = "k8s_version";
         authors = [
@@ -9509,8 +9509,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "c366edd287d177cd8d69fe3351bf0cc797ef2e4c";
-          sha256 = "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb";
+          rev = "451088f77acee6c3d296754698260256c250ecb2";
+          sha256 = "1ifdpn0jvrf3xbgqldqxrq9ig1dc34d4fip7qxn38526k8004p4b";
         };
         libName = "stackable_certs";
         authors = [
@@ -9706,8 +9706,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "c366edd287d177cd8d69fe3351bf0cc797ef2e4c";
-          sha256 = "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb";
+          rev = "451088f77acee6c3d296754698260256c250ecb2";
+          sha256 = "1ifdpn0jvrf3xbgqldqxrq9ig1dc34d4fip7qxn38526k8004p4b";
         };
         libName = "stackable_operator";
         authors = [
@@ -9900,8 +9900,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "c366edd287d177cd8d69fe3351bf0cc797ef2e4c";
-          sha256 = "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb";
+          rev = "451088f77acee6c3d296754698260256c250ecb2";
+          sha256 = "1ifdpn0jvrf3xbgqldqxrq9ig1dc34d4fip7qxn38526k8004p4b";
         };
         procMacro = true;
         libName = "stackable_operator_derive";
@@ -9935,8 +9935,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "c366edd287d177cd8d69fe3351bf0cc797ef2e4c";
-          sha256 = "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb";
+          rev = "451088f77acee6c3d296754698260256c250ecb2";
+          sha256 = "1ifdpn0jvrf3xbgqldqxrq9ig1dc34d4fip7qxn38526k8004p4b";
         };
         libName = "stackable_shared";
         authors = [
@@ -10016,8 +10016,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "c366edd287d177cd8d69fe3351bf0cc797ef2e4c";
-          sha256 = "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb";
+          rev = "451088f77acee6c3d296754698260256c250ecb2";
+          sha256 = "1ifdpn0jvrf3xbgqldqxrq9ig1dc34d4fip7qxn38526k8004p4b";
         };
         libName = "stackable_telemetry";
         authors = [
@@ -10126,8 +10126,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "c366edd287d177cd8d69fe3351bf0cc797ef2e4c";
-          sha256 = "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb";
+          rev = "451088f77acee6c3d296754698260256c250ecb2";
+          sha256 = "1ifdpn0jvrf3xbgqldqxrq9ig1dc34d4fip7qxn38526k8004p4b";
         };
         libName = "stackable_versioned";
         authors = [
@@ -10176,8 +10176,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "c366edd287d177cd8d69fe3351bf0cc797ef2e4c";
-          sha256 = "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb";
+          rev = "451088f77acee6c3d296754698260256c250ecb2";
+          sha256 = "1ifdpn0jvrf3xbgqldqxrq9ig1dc34d4fip7qxn38526k8004p4b";
         };
         procMacro = true;
         libName = "stackable_versioned_macros";
@@ -10244,8 +10244,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "c366edd287d177cd8d69fe3351bf0cc797ef2e4c";
-          sha256 = "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb";
+          rev = "451088f77acee6c3d296754698260256c250ecb2";
+          sha256 = "1ifdpn0jvrf3xbgqldqxrq9ig1dc34d4fip7qxn38526k8004p4b";
         };
         libName = "stackable_webhook";
         authors = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,6 @@ tracing = "0.1"
 tracing-futures = { version = "0.2", features = ["futures-03"] }
 
 [patch."https://github.com/stackabletech/operator-rs.git"]
-stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "smooth-operator" }
+stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "feat/improve-keyvalueconfigoverrides" }
 # stackable-operator = { path = "../operator-rs/crates/stackable-operator" }
 # stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,6 @@ tracing = "0.1"
 tracing-futures = { version = "0.2", features = ["futures-03"] }
 
 [patch."https://github.com/stackabletech/operator-rs.git"]
-stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "feat/improve-keyvalueconfigoverrides" }
+stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "smooth-operator" }
 # stackable-operator = { path = "../operator-rs/crates/stackable-operator" }
 # stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "main" }

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,12 +1,12 @@
 {
-  "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#k8s-version@0.1.3": "0idpq1xdkr94zrd95xsvrwkj3bvzbii9a7qmw23rn5w4yiwgmj96",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#stackable-certs@0.4.0": "0idpq1xdkr94zrd95xsvrwkj3bvzbii9a7qmw23rn5w4yiwgmj96",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#stackable-operator-derive@0.3.1": "0idpq1xdkr94zrd95xsvrwkj3bvzbii9a7qmw23rn5w4yiwgmj96",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#stackable-operator@0.111.1": "0idpq1xdkr94zrd95xsvrwkj3bvzbii9a7qmw23rn5w4yiwgmj96",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#stackable-shared@0.1.1": "0idpq1xdkr94zrd95xsvrwkj3bvzbii9a7qmw23rn5w4yiwgmj96",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#stackable-telemetry@0.6.4": "0idpq1xdkr94zrd95xsvrwkj3bvzbii9a7qmw23rn5w4yiwgmj96",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#stackable-versioned-macros@0.10.0": "0idpq1xdkr94zrd95xsvrwkj3bvzbii9a7qmw23rn5w4yiwgmj96",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#stackable-versioned@0.10.0": "0idpq1xdkr94zrd95xsvrwkj3bvzbii9a7qmw23rn5w4yiwgmj96",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#stackable-webhook@0.9.1": "0idpq1xdkr94zrd95xsvrwkj3bvzbii9a7qmw23rn5w4yiwgmj96",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#k8s-version@0.1.3": "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#stackable-certs@0.4.0": "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#stackable-operator-derive@0.3.1": "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#stackable-operator@0.111.1": "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#stackable-shared@0.1.1": "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#stackable-telemetry@0.6.4": "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#stackable-versioned-macros@0.10.0": "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#stackable-versioned@0.10.0": "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#stackable-webhook@0.9.1": "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb",
   "git+https://github.com/stackabletech/product-config.git?tag=0.8.0#product-config@0.8.0": "1dz70kapm2wdqcr7ndyjji0lhsl98bsq95gnb2lw487wf6yr7987"
 }

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,12 +1,12 @@
 {
-  "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#k8s-version@0.1.3": "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#stackable-certs@0.4.0": "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#stackable-operator-derive@0.3.1": "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#stackable-operator@0.111.1": "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#stackable-shared@0.1.1": "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#stackable-telemetry@0.6.4": "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#stackable-versioned-macros@0.10.0": "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#stackable-versioned@0.10.0": "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=feat%2Fimprove-keyvalueconfigoverrides#stackable-webhook@0.9.1": "1alg0z5v2j8xy5lr8k799kf9q6qnqg7416irndzz97llp796gvbb",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#k8s-version@0.1.3": "1ifdpn0jvrf3xbgqldqxrq9ig1dc34d4fip7qxn38526k8004p4b",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#stackable-certs@0.4.0": "1ifdpn0jvrf3xbgqldqxrq9ig1dc34d4fip7qxn38526k8004p4b",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#stackable-operator-derive@0.3.1": "1ifdpn0jvrf3xbgqldqxrq9ig1dc34d4fip7qxn38526k8004p4b",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#stackable-operator@0.111.1": "1ifdpn0jvrf3xbgqldqxrq9ig1dc34d4fip7qxn38526k8004p4b",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#stackable-shared@0.1.1": "1ifdpn0jvrf3xbgqldqxrq9ig1dc34d4fip7qxn38526k8004p4b",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#stackable-telemetry@0.6.4": "1ifdpn0jvrf3xbgqldqxrq9ig1dc34d4fip7qxn38526k8004p4b",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#stackable-versioned-macros@0.10.0": "1ifdpn0jvrf3xbgqldqxrq9ig1dc34d4fip7qxn38526k8004p4b",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#stackable-versioned@0.10.0": "1ifdpn0jvrf3xbgqldqxrq9ig1dc34d4fip7qxn38526k8004p4b",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=smooth-operator#stackable-webhook@0.9.1": "1ifdpn0jvrf3xbgqldqxrq9ig1dc34d4fip7qxn38526k8004p4b",
   "git+https://github.com/stackabletech/product-config.git?tag=0.8.0#product-config@0.8.0": "1dz70kapm2wdqcr7ndyjji0lhsl98bsq95gnb2lw487wf6yr7987"
 }

--- a/extra/crds.yaml
+++ b/extra/crds.yaml
@@ -606,7 +606,6 @@ spec:
                     properties:
                       core-site.xml:
                         additionalProperties:
-                          nullable: true
                           type: string
                         default: {}
                         description: |-
@@ -617,7 +616,6 @@ spec:
                         type: object
                       hadoop-policy.xml:
                         additionalProperties:
-                          nullable: true
                           type: string
                         default: {}
                         description: |-
@@ -628,7 +626,6 @@ spec:
                         type: object
                       hdfs-site.xml:
                         additionalProperties:
-                          nullable: true
                           type: string
                         default: {}
                         description: |-
@@ -639,7 +636,6 @@ spec:
                         type: object
                       security.properties:
                         additionalProperties:
-                          nullable: true
                           type: string
                         default: {}
                         description: |-
@@ -650,7 +646,6 @@ spec:
                         type: object
                       ssl-client.xml:
                         additionalProperties:
-                          nullable: true
                           type: string
                         default: {}
                         description: |-
@@ -661,7 +656,6 @@ spec:
                         type: object
                       ssl-server.xml:
                         additionalProperties:
-                          nullable: true
                           type: string
                         default: {}
                         description: |-
@@ -1199,7 +1193,6 @@ spec:
                           properties:
                             core-site.xml:
                               additionalProperties:
-                                nullable: true
                                 type: string
                               default: {}
                               description: |-
@@ -1210,7 +1203,6 @@ spec:
                               type: object
                             hadoop-policy.xml:
                               additionalProperties:
-                                nullable: true
                                 type: string
                               default: {}
                               description: |-
@@ -1221,7 +1213,6 @@ spec:
                               type: object
                             hdfs-site.xml:
                               additionalProperties:
-                                nullable: true
                                 type: string
                               default: {}
                               description: |-
@@ -1232,7 +1223,6 @@ spec:
                               type: object
                             security.properties:
                               additionalProperties:
-                                nullable: true
                                 type: string
                               default: {}
                               description: |-
@@ -1243,7 +1233,6 @@ spec:
                               type: object
                             ssl-client.xml:
                               additionalProperties:
-                                nullable: true
                                 type: string
                               default: {}
                               description: |-
@@ -1254,7 +1243,6 @@ spec:
                               type: object
                             ssl-server.xml:
                               additionalProperties:
-                                nullable: true
                                 type: string
                               default: {}
                               description: |-
@@ -1738,7 +1726,6 @@ spec:
                     properties:
                       core-site.xml:
                         additionalProperties:
-                          nullable: true
                           type: string
                         default: {}
                         description: |-
@@ -1749,7 +1736,6 @@ spec:
                         type: object
                       hadoop-policy.xml:
                         additionalProperties:
-                          nullable: true
                           type: string
                         default: {}
                         description: |-
@@ -1760,7 +1746,6 @@ spec:
                         type: object
                       hdfs-site.xml:
                         additionalProperties:
-                          nullable: true
                           type: string
                         default: {}
                         description: |-
@@ -1771,7 +1756,6 @@ spec:
                         type: object
                       security.properties:
                         additionalProperties:
-                          nullable: true
                           type: string
                         default: {}
                         description: |-
@@ -1782,7 +1766,6 @@ spec:
                         type: object
                       ssl-client.xml:
                         additionalProperties:
-                          nullable: true
                           type: string
                         default: {}
                         description: |-
@@ -1793,7 +1776,6 @@ spec:
                         type: object
                       ssl-server.xml:
                         additionalProperties:
-                          nullable: true
                           type: string
                         default: {}
                         description: |-
@@ -2234,7 +2216,6 @@ spec:
                           properties:
                             core-site.xml:
                               additionalProperties:
-                                nullable: true
                                 type: string
                               default: {}
                               description: |-
@@ -2245,7 +2226,6 @@ spec:
                               type: object
                             hadoop-policy.xml:
                               additionalProperties:
-                                nullable: true
                                 type: string
                               default: {}
                               description: |-
@@ -2256,7 +2236,6 @@ spec:
                               type: object
                             hdfs-site.xml:
                               additionalProperties:
-                                nullable: true
                                 type: string
                               default: {}
                               description: |-
@@ -2267,7 +2246,6 @@ spec:
                               type: object
                             security.properties:
                               additionalProperties:
-                                nullable: true
                                 type: string
                               default: {}
                               description: |-
@@ -2278,7 +2256,6 @@ spec:
                               type: object
                             ssl-client.xml:
                               additionalProperties:
-                                nullable: true
                                 type: string
                               default: {}
                               description: |-
@@ -2289,7 +2266,6 @@ spec:
                               type: object
                             ssl-server.xml:
                               additionalProperties:
-                                nullable: true
                                 type: string
                               default: {}
                               description: |-
@@ -2956,7 +2932,6 @@ spec:
                     properties:
                       core-site.xml:
                         additionalProperties:
-                          nullable: true
                           type: string
                         default: {}
                         description: |-
@@ -2967,7 +2942,6 @@ spec:
                         type: object
                       hadoop-policy.xml:
                         additionalProperties:
-                          nullable: true
                           type: string
                         default: {}
                         description: |-
@@ -2978,7 +2952,6 @@ spec:
                         type: object
                       hdfs-site.xml:
                         additionalProperties:
-                          nullable: true
                           type: string
                         default: {}
                         description: |-
@@ -2989,7 +2962,6 @@ spec:
                         type: object
                       security.properties:
                         additionalProperties:
-                          nullable: true
                           type: string
                         default: {}
                         description: |-
@@ -3000,7 +2972,6 @@ spec:
                         type: object
                       ssl-client.xml:
                         additionalProperties:
-                          nullable: true
                           type: string
                         default: {}
                         description: |-
@@ -3011,7 +2982,6 @@ spec:
                         type: object
                       ssl-server.xml:
                         additionalProperties:
-                          nullable: true
                           type: string
                         default: {}
                         description: |-
@@ -3698,7 +3668,6 @@ spec:
                           properties:
                             core-site.xml:
                               additionalProperties:
-                                nullable: true
                                 type: string
                               default: {}
                               description: |-
@@ -3709,7 +3678,6 @@ spec:
                               type: object
                             hadoop-policy.xml:
                               additionalProperties:
-                                nullable: true
                                 type: string
                               default: {}
                               description: |-
@@ -3720,7 +3688,6 @@ spec:
                               type: object
                             hdfs-site.xml:
                               additionalProperties:
-                                nullable: true
                                 type: string
                               default: {}
                               description: |-
@@ -3731,7 +3698,6 @@ spec:
                               type: object
                             security.properties:
                               additionalProperties:
-                                nullable: true
                                 type: string
                               default: {}
                               description: |-
@@ -3742,7 +3708,6 @@ spec:
                               type: object
                             ssl-client.xml:
                               additionalProperties:
-                                nullable: true
                                 type: string
                               default: {}
                               description: |-
@@ -3753,7 +3718,6 @@ spec:
                               type: object
                             ssl-server.xml:
                               additionalProperties:
-                                nullable: true
                                 type: string
                               default: {}
                               description: |-

--- a/extra/crds.yaml
+++ b/extra/crds.yaml
@@ -608,61 +608,37 @@ spec:
                         additionalProperties:
                           type: string
                         default: {}
-                        description: |-
-                          Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                          This is backwards-compatible with the existing flat key-value YAML format
-                          used by `HashMap<String, String>`.
+                        description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                         type: object
                       hadoop-policy.xml:
                         additionalProperties:
                           type: string
                         default: {}
-                        description: |-
-                          Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                          This is backwards-compatible with the existing flat key-value YAML format
-                          used by `HashMap<String, String>`.
+                        description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                         type: object
                       hdfs-site.xml:
                         additionalProperties:
                           type: string
                         default: {}
-                        description: |-
-                          Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                          This is backwards-compatible with the existing flat key-value YAML format
-                          used by `HashMap<String, String>`.
+                        description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                         type: object
                       security.properties:
                         additionalProperties:
                           type: string
                         default: {}
-                        description: |-
-                          Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                          This is backwards-compatible with the existing flat key-value YAML format
-                          used by `HashMap<String, String>`.
+                        description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                         type: object
                       ssl-client.xml:
                         additionalProperties:
                           type: string
                         default: {}
-                        description: |-
-                          Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                          This is backwards-compatible with the existing flat key-value YAML format
-                          used by `HashMap<String, String>`.
+                        description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                         type: object
                       ssl-server.xml:
                         additionalProperties:
                           type: string
                         default: {}
-                        description: |-
-                          Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                          This is backwards-compatible with the existing flat key-value YAML format
-                          used by `HashMap<String, String>`.
+                        description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                         type: object
                     type: object
                   envOverrides:
@@ -1195,61 +1171,37 @@ spec:
                               additionalProperties:
                                 type: string
                               default: {}
-                              description: |-
-                                Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                                This is backwards-compatible with the existing flat key-value YAML format
-                                used by `HashMap<String, String>`.
+                              description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                               type: object
                             hadoop-policy.xml:
                               additionalProperties:
                                 type: string
                               default: {}
-                              description: |-
-                                Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                                This is backwards-compatible with the existing flat key-value YAML format
-                                used by `HashMap<String, String>`.
+                              description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                               type: object
                             hdfs-site.xml:
                               additionalProperties:
                                 type: string
                               default: {}
-                              description: |-
-                                Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                                This is backwards-compatible with the existing flat key-value YAML format
-                                used by `HashMap<String, String>`.
+                              description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                               type: object
                             security.properties:
                               additionalProperties:
                                 type: string
                               default: {}
-                              description: |-
-                                Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                                This is backwards-compatible with the existing flat key-value YAML format
-                                used by `HashMap<String, String>`.
+                              description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                               type: object
                             ssl-client.xml:
                               additionalProperties:
                                 type: string
                               default: {}
-                              description: |-
-                                Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                                This is backwards-compatible with the existing flat key-value YAML format
-                                used by `HashMap<String, String>`.
+                              description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                               type: object
                             ssl-server.xml:
                               additionalProperties:
                                 type: string
                               default: {}
-                              description: |-
-                                Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                                This is backwards-compatible with the existing flat key-value YAML format
-                                used by `HashMap<String, String>`.
+                              description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                               type: object
                           type: object
                         envOverrides:
@@ -1728,61 +1680,37 @@ spec:
                         additionalProperties:
                           type: string
                         default: {}
-                        description: |-
-                          Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                          This is backwards-compatible with the existing flat key-value YAML format
-                          used by `HashMap<String, String>`.
+                        description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                         type: object
                       hadoop-policy.xml:
                         additionalProperties:
                           type: string
                         default: {}
-                        description: |-
-                          Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                          This is backwards-compatible with the existing flat key-value YAML format
-                          used by `HashMap<String, String>`.
+                        description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                         type: object
                       hdfs-site.xml:
                         additionalProperties:
                           type: string
                         default: {}
-                        description: |-
-                          Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                          This is backwards-compatible with the existing flat key-value YAML format
-                          used by `HashMap<String, String>`.
+                        description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                         type: object
                       security.properties:
                         additionalProperties:
                           type: string
                         default: {}
-                        description: |-
-                          Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                          This is backwards-compatible with the existing flat key-value YAML format
-                          used by `HashMap<String, String>`.
+                        description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                         type: object
                       ssl-client.xml:
                         additionalProperties:
                           type: string
                         default: {}
-                        description: |-
-                          Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                          This is backwards-compatible with the existing flat key-value YAML format
-                          used by `HashMap<String, String>`.
+                        description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                         type: object
                       ssl-server.xml:
                         additionalProperties:
                           type: string
                         default: {}
-                        description: |-
-                          Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                          This is backwards-compatible with the existing flat key-value YAML format
-                          used by `HashMap<String, String>`.
+                        description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                         type: object
                     type: object
                   envOverrides:
@@ -2218,61 +2146,37 @@ spec:
                               additionalProperties:
                                 type: string
                               default: {}
-                              description: |-
-                                Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                                This is backwards-compatible with the existing flat key-value YAML format
-                                used by `HashMap<String, String>`.
+                              description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                               type: object
                             hadoop-policy.xml:
                               additionalProperties:
                                 type: string
                               default: {}
-                              description: |-
-                                Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                                This is backwards-compatible with the existing flat key-value YAML format
-                                used by `HashMap<String, String>`.
+                              description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                               type: object
                             hdfs-site.xml:
                               additionalProperties:
                                 type: string
                               default: {}
-                              description: |-
-                                Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                                This is backwards-compatible with the existing flat key-value YAML format
-                                used by `HashMap<String, String>`.
+                              description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                               type: object
                             security.properties:
                               additionalProperties:
                                 type: string
                               default: {}
-                              description: |-
-                                Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                                This is backwards-compatible with the existing flat key-value YAML format
-                                used by `HashMap<String, String>`.
+                              description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                               type: object
                             ssl-client.xml:
                               additionalProperties:
                                 type: string
                               default: {}
-                              description: |-
-                                Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                                This is backwards-compatible with the existing flat key-value YAML format
-                                used by `HashMap<String, String>`.
+                              description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                               type: object
                             ssl-server.xml:
                               additionalProperties:
                                 type: string
                               default: {}
-                              description: |-
-                                Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                                This is backwards-compatible with the existing flat key-value YAML format
-                                used by `HashMap<String, String>`.
+                              description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                               type: object
                           type: object
                         envOverrides:
@@ -2934,61 +2838,37 @@ spec:
                         additionalProperties:
                           type: string
                         default: {}
-                        description: |-
-                          Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                          This is backwards-compatible with the existing flat key-value YAML format
-                          used by `HashMap<String, String>`.
+                        description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                         type: object
                       hadoop-policy.xml:
                         additionalProperties:
                           type: string
                         default: {}
-                        description: |-
-                          Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                          This is backwards-compatible with the existing flat key-value YAML format
-                          used by `HashMap<String, String>`.
+                        description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                         type: object
                       hdfs-site.xml:
                         additionalProperties:
                           type: string
                         default: {}
-                        description: |-
-                          Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                          This is backwards-compatible with the existing flat key-value YAML format
-                          used by `HashMap<String, String>`.
+                        description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                         type: object
                       security.properties:
                         additionalProperties:
                           type: string
                         default: {}
-                        description: |-
-                          Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                          This is backwards-compatible with the existing flat key-value YAML format
-                          used by `HashMap<String, String>`.
+                        description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                         type: object
                       ssl-client.xml:
                         additionalProperties:
                           type: string
                         default: {}
-                        description: |-
-                          Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                          This is backwards-compatible with the existing flat key-value YAML format
-                          used by `HashMap<String, String>`.
+                        description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                         type: object
                       ssl-server.xml:
                         additionalProperties:
                           type: string
                         default: {}
-                        description: |-
-                          Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                          This is backwards-compatible with the existing flat key-value YAML format
-                          used by `HashMap<String, String>`.
+                        description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                         type: object
                     type: object
                   envOverrides:
@@ -3670,61 +3550,37 @@ spec:
                               additionalProperties:
                                 type: string
                               default: {}
-                              description: |-
-                                Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                                This is backwards-compatible with the existing flat key-value YAML format
-                                used by `HashMap<String, String>`.
+                              description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                               type: object
                             hadoop-policy.xml:
                               additionalProperties:
                                 type: string
                               default: {}
-                              description: |-
-                                Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                                This is backwards-compatible with the existing flat key-value YAML format
-                                used by `HashMap<String, String>`.
+                              description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                               type: object
                             hdfs-site.xml:
                               additionalProperties:
                                 type: string
                               default: {}
-                              description: |-
-                                Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                                This is backwards-compatible with the existing flat key-value YAML format
-                                used by `HashMap<String, String>`.
+                              description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                               type: object
                             security.properties:
                               additionalProperties:
                                 type: string
                               default: {}
-                              description: |-
-                                Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                                This is backwards-compatible with the existing flat key-value YAML format
-                                used by `HashMap<String, String>`.
+                              description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                               type: object
                             ssl-client.xml:
                               additionalProperties:
                                 type: string
                               default: {}
-                              description: |-
-                                Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                                This is backwards-compatible with the existing flat key-value YAML format
-                                used by `HashMap<String, String>`.
+                              description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                               type: object
                             ssl-server.xml:
                               additionalProperties:
                                 type: string
                               default: {}
-                              description: |-
-                                Flat key-value overrides for `*.properties`, Hadoop XML, etc.
-
-                                This is backwards-compatible with the existing flat key-value YAML format
-                                used by `HashMap<String, String>`.
+                              description: Flat key-value overrides for `*.properties`, Hadoop XML, etc.
                               type: object
                           type: object
                         envOverrides:

--- a/rust/operator-binary/src/config/mod.rs
+++ b/rust/operator-binary/src/config/mod.rs
@@ -40,8 +40,8 @@ impl HdfsSiteConfigBuilder {
         self
     }
 
-    pub fn extend(&mut self, properties: &BTreeMap<String, String>) -> &mut Self {
-        self.config.extend(properties.clone());
+    pub fn extend(&mut self, properties: impl IntoIterator<Item = (String, String)>) -> &mut Self {
+        self.config.extend(properties);
         self
     }
 
@@ -238,8 +238,8 @@ impl CoreSiteConfigBuilder {
         self
     }
 
-    pub fn extend(&mut self, properties: &BTreeMap<String, String>) -> &mut Self {
-        self.config.extend(properties.clone());
+    pub fn extend(&mut self, properties: impl IntoIterator<Item = (String, String)>) -> &mut Self {
+        self.config.extend(properties);
         self
     }
 

--- a/rust/operator-binary/src/controller/build/properties/core_site.rs
+++ b/rust/operator-binary/src/controller/build/properties/core_site.rs
@@ -1,14 +1,12 @@
 //! Builds the `core-site.xml` config file.
 
-use std::collections::BTreeMap;
-
 use stackable_operator::{
     utils::cluster_info::KubernetesClusterInfo, v2::config_overrides::KeyValueConfigOverrides,
 };
 
 use crate::{
-    config::CoreSiteConfigBuilder, controller::build::properties::resolved_overrides,
-    crd::HdfsNodeRole, hdfs_controller::ValidatedCluster, security::kerberos::KerberosConfig,
+    config::CoreSiteConfigBuilder, crd::HdfsNodeRole, hdfs_controller::ValidatedCluster,
+    security::kerberos::KerberosConfig,
 };
 
 /// Renders `core-site.xml`: operator defaults + kerberos/OPA security config,
@@ -48,16 +46,13 @@ pub fn build(
         opa_config.add_core_site_config(&mut core_site);
     }
     // the extend with config must come last in order to have overrides working!!!
-    let overrides: BTreeMap<String, String> = resolved_overrides(overrides).collect();
-    core_site.extend(&overrides).build_as_xml()
+    core_site.extend(overrides).build_as_xml()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::controller::build::properties::test_support::{
-        cluster_info, config_overrides, validated_cluster,
-    };
+    use crate::controller::build::properties::test_support::{cluster_info, validated_cluster};
 
     #[test]
     fn renders_operator_defaults() {
@@ -65,7 +60,7 @@ mod tests {
             &validated_cluster(),
             HdfsNodeRole::Name,
             &cluster_info(),
-            config_overrides(&[]),
+            KeyValueConfigOverrides::default(),
         );
         assert!(
             xml.contains("<name>fs.defaultFS</name>\n    <value>hdfs://hdfs/</value>"),
@@ -89,7 +84,7 @@ mod tests {
             &validated_cluster(),
             HdfsNodeRole::Name,
             &cluster_info(),
-            config_overrides(&[("io.file.buffer.size", "65536")]),
+            [("io.file.buffer.size", "65536")].into(),
         );
         assert!(
             xml.contains("<name>io.file.buffer.size</name>\n    <value>65536</value>"),

--- a/rust/operator-binary/src/controller/build/properties/hadoop_policy.rs
+++ b/rust/operator-binary/src/controller/build/properties/hadoop_policy.rs
@@ -3,29 +3,23 @@
 //! The operator sets no defaults here; the file exists purely so users can
 //! supply `configOverrides`.
 
-use std::collections::BTreeMap;
-
 use stackable_operator::v2::{
     config_file_writer::to_hadoop_xml, config_overrides::KeyValueConfigOverrides,
 };
 
-use crate::controller::build::properties::resolved_overrides;
-
 /// Renders `hadoop-policy.xml` from the user-provided overrides only.
 pub fn build(overrides: KeyValueConfigOverrides) -> String {
-    let config: BTreeMap<String, String> = resolved_overrides(overrides).collect();
-    to_hadoop_xml(config.iter())
+    to_hadoop_xml(overrides.iter())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::controller::build::properties::test_support::config_overrides;
 
     #[test]
     fn empty_overrides_render_empty_configuration() {
         assert_eq!(
-            build(config_overrides(&[])),
+            build(KeyValueConfigOverrides::default()),
             concat!(
                 "<?xml version=\"1.0\"?>\n",
                 "<configuration>\n",
@@ -37,7 +31,7 @@ mod tests {
     #[test]
     fn overrides_are_rendered_as_properties() {
         assert_eq!(
-            build(config_overrides(&[("security.client.protocol.acl", "*")])),
+            build([("security.client.protocol.acl", "*")].into()),
             concat!(
                 "<?xml version=\"1.0\"?>\n",
                 "<configuration>\n",

--- a/rust/operator-binary/src/controller/build/properties/hdfs_site.rs
+++ b/rust/operator-binary/src/controller/build/properties/hdfs_site.rs
@@ -1,14 +1,11 @@
 //! Builds the `hdfs-site.xml` config file.
 
-use std::collections::BTreeMap;
-
 use stackable_operator::{
     utils::cluster_info::KubernetesClusterInfo, v2::config_overrides::KeyValueConfigOverrides,
 };
 
 use crate::{
     config::HdfsSiteConfigBuilder,
-    controller::build::properties::resolved_overrides,
     crd::{AnyNodeConfig, HdfsNodeRole},
     hdfs_controller::ValidatedCluster,
 };
@@ -110,8 +107,7 @@ pub fn build(
         opa_config.add_hdfs_site_config(&mut hdfs_site);
     }
     // the extend with config must come last in order to have overrides working!!!
-    let overrides: BTreeMap<String, String> = resolved_overrides(overrides).collect();
-    hdfs_site.extend(&overrides).build_as_xml()
+    hdfs_site.extend(overrides).build_as_xml()
 }
 
 #[cfg(test)]
@@ -119,7 +115,7 @@ mod tests {
     use super::*;
     use crate::{
         controller::build::properties::test_support::{
-            cluster_info, config_overrides, minimal_hdfs, validated_cluster,
+            cluster_info, minimal_hdfs, validated_cluster,
         },
         crd::{HdfsNodeRole, v1alpha1},
     };
@@ -137,7 +133,7 @@ mod tests {
             &validated_cluster(),
             &cluster_info(),
             &merged,
-            config_overrides(&[]),
+            KeyValueConfigOverrides::default(),
         );
         assert!(
             xml.contains("<name>dfs.replication</name>\n    <value>3</value>"),
@@ -156,7 +152,7 @@ mod tests {
             &validated_cluster(),
             &cluster_info(),
             &merged,
-            config_overrides(&[("dfs.replication", "5")]),
+            [("dfs.replication", "5")].into(),
         );
         assert!(
             xml.contains("<name>dfs.replication</name>\n    <value>5</value>"),

--- a/rust/operator-binary/src/controller/build/properties/mod.rs
+++ b/rust/operator-binary/src/controller/build/properties/mod.rs
@@ -3,10 +3,6 @@
 //! config file; the shared [`stackable_operator::v2::config_file_writer`]
 //! module serializes maps to the Hadoop-XML / Java-properties on-wire format.
 
-use std::collections::BTreeMap;
-
-use stackable_operator::v2::config_overrides::KeyValueConfigOverrides;
-
 pub mod core_site;
 pub mod hadoop_policy;
 pub mod hdfs_site;
@@ -14,23 +10,6 @@ pub mod logging;
 pub mod security_properties;
 pub mod ssl_client;
 pub mod ssl_server;
-
-/// Keep only the set (`Some`) entries of a `key -> optional value` map, as `(key, value)` pairs.
-fn defined_entries(
-    entries: BTreeMap<String, Option<String>>,
-) -> impl Iterator<Item = (String, String)> {
-    entries
-        .into_iter()
-        .filter_map(|(key, value)| value.map(|value| (key, value)))
-}
-
-/// Resolve user-provided [`KeyValueConfigOverrides`] into the key/value pairs to merge
-/// into a config file, dropping entries whose value is unset (`None`).
-fn resolved_overrides(
-    overrides: KeyValueConfigOverrides,
-) -> impl Iterator<Item = (String, String)> {
-    defined_entries(overrides.overrides)
-}
 
 /// The names of the HDFS config files assembled into the rolegroup `ConfigMap`.
 #[derive(Clone, Copy, Debug, strum::Display)]
@@ -71,22 +50,11 @@ mod tests {
 pub(crate) mod test_support {
     use stackable_operator::{
         commons::networking::DomainName, utils::cluster_info::KubernetesClusterInfo,
-        v2::config_overrides::KeyValueConfigOverrides,
     };
 
     use crate::{
         controller::validate::validate_cluster, crd::v1alpha1, hdfs_controller::ValidatedCluster,
     };
-
-    /// Builds a [`KeyValueConfigOverrides`] from `(key, value)` pairs for tests.
-    pub fn config_overrides(pairs: &[(&str, &str)]) -> KeyValueConfigOverrides {
-        KeyValueConfigOverrides {
-            overrides: pairs
-                .iter()
-                .map(|(k, v)| (k.to_string(), Some(v.to_string())))
-                .collect(),
-        }
-    }
 
     /// A minimal three-role HdfsCluster used to drive the per-file builder tests.
     pub const MINIMAL_HDFS_YAML: &str = r#"

--- a/rust/operator-binary/src/controller/build/properties/security_properties.rs
+++ b/rust/operator-binary/src/controller/build/properties/security_properties.rs
@@ -10,8 +10,6 @@ use stackable_operator::v2::{
     config_overrides::KeyValueConfigOverrides,
 };
 
-use crate::controller::build::properties::resolved_overrides;
-
 /// Renders `security.properties`: recommended DNS cache TTLs plus user overrides.
 pub fn build(overrides: KeyValueConfigOverrides) -> Result<String, PropertiesWriterError> {
     // Recommended JVM DNS cache TTLs. Caching forever (the JVM default for
@@ -25,19 +23,18 @@ pub fn build(overrides: KeyValueConfigOverrides) -> Result<String, PropertiesWri
         ),
     ]);
     // Overrides applied last so users win.
-    config.extend(resolved_overrides(overrides));
+    config.extend(overrides);
     to_java_properties_string(config.iter())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::controller::build::properties::test_support::config_overrides;
 
     #[test]
     fn injects_recommended_dns_cache_ttls() {
         assert_eq!(
-            build(config_overrides(&[])).unwrap(),
+            build(KeyValueConfigOverrides::default()).unwrap(),
             "networkaddress.cache.negative.ttl=0\nnetworkaddress.cache.ttl=30\n"
         );
     }
@@ -45,7 +42,7 @@ mod tests {
     #[test]
     fn user_overrides_win_over_injected_defaults() {
         assert_eq!(
-            build(config_overrides(&[("networkaddress.cache.ttl", "60")])).unwrap(),
+            build([("networkaddress.cache.ttl", "60")].into()).unwrap(),
             "networkaddress.cache.negative.ttl=0\nnetworkaddress.cache.ttl=60\n"
         );
     }
@@ -53,7 +50,7 @@ mod tests {
     #[test]
     fn extra_overrides_are_appended() {
         assert_eq!(
-            build(config_overrides(&[("foo.bar", "baz")])).unwrap(),
+            build([("foo.bar", "baz")].into()).unwrap(),
             "foo.bar=baz\nnetworkaddress.cache.negative.ttl=0\nnetworkaddress.cache.ttl=30\n"
         );
     }

--- a/rust/operator-binary/src/controller/build/properties/ssl_client.rs
+++ b/rust/operator-binary/src/controller/build/properties/ssl_client.rs
@@ -9,10 +9,7 @@ use stackable_operator::v2::{
     config_file_writer::to_hadoop_xml, config_overrides::KeyValueConfigOverrides,
 };
 
-use crate::{
-    container::{TLS_STORE_DIR, TLS_STORE_PASSWORD},
-    controller::build::properties::resolved_overrides,
-};
+use crate::container::{TLS_STORE_DIR, TLS_STORE_PASSWORD};
 
 /// Renders `ssl-client.xml` for the given HTTPS state and user overrides.
 pub fn build(https_enabled: bool, overrides: KeyValueConfigOverrides) -> String {
@@ -34,19 +31,18 @@ pub fn build(https_enabled: bool, overrides: KeyValueConfigOverrides) -> String 
         ]);
     }
     // Overrides applied last so users win.
-    config.extend(resolved_overrides(overrides));
+    config.extend(overrides);
     to_hadoop_xml(config.iter())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::controller::build::properties::test_support::config_overrides;
 
     #[test]
     fn disabled_https_without_overrides_renders_empty_configuration() {
         assert_eq!(
-            build(false, config_overrides(&[])),
+            build(false, KeyValueConfigOverrides::default()),
             concat!(
                 "<?xml version=\"1.0\"?>\n",
                 "<configuration>\n",
@@ -57,7 +53,7 @@ mod tests {
 
     #[test]
     fn enabled_https_injects_truststore() {
-        let xml = build(true, config_overrides(&[]));
+        let xml = build(true, KeyValueConfigOverrides::default());
         assert!(
             xml.contains(&format!(
                 "<name>ssl.client.truststore.location</name>\n    <value>{TLS_STORE_DIR}/truststore.p12</value>"
@@ -74,10 +70,7 @@ mod tests {
 
     #[test]
     fn user_overrides_win_over_injected_defaults() {
-        let xml = build(
-            true,
-            config_overrides(&[("ssl.client.truststore.type", "jks")]),
-        );
+        let xml = build(true, [("ssl.client.truststore.type", "jks")].into());
         assert!(
             xml.contains("<name>ssl.client.truststore.type</name>\n    <value>jks</value>"),
             "{xml}"

--- a/rust/operator-binary/src/controller/build/properties/ssl_server.rs
+++ b/rust/operator-binary/src/controller/build/properties/ssl_server.rs
@@ -9,10 +9,7 @@ use stackable_operator::v2::{
     config_file_writer::to_hadoop_xml, config_overrides::KeyValueConfigOverrides,
 };
 
-use crate::{
-    container::{TLS_STORE_DIR, TLS_STORE_PASSWORD},
-    controller::build::properties::resolved_overrides,
-};
+use crate::container::{TLS_STORE_DIR, TLS_STORE_PASSWORD};
 
 /// Renders `ssl-server.xml` for the given HTTPS state and user overrides.
 pub fn build(https_enabled: bool, overrides: KeyValueConfigOverrides) -> String {
@@ -43,19 +40,18 @@ pub fn build(https_enabled: bool, overrides: KeyValueConfigOverrides) -> String 
         ]);
     }
     // Overrides applied last so users win.
-    config.extend(resolved_overrides(overrides));
+    config.extend(overrides);
     to_hadoop_xml(config.iter())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::controller::build::properties::test_support::config_overrides;
 
     #[test]
     fn disabled_https_without_overrides_renders_empty_configuration() {
         assert_eq!(
-            build(false, config_overrides(&[])),
+            build(false, KeyValueConfigOverrides::default()),
             concat!(
                 "<?xml version=\"1.0\"?>\n",
                 "<configuration>\n",
@@ -66,7 +62,7 @@ mod tests {
 
     #[test]
     fn enabled_https_injects_keystore_and_truststore() {
-        let xml = build(true, config_overrides(&[]));
+        let xml = build(true, KeyValueConfigOverrides::default());
         assert!(
             xml.contains(&format!(
                 "<name>ssl.server.keystore.location</name>\n    <value>{TLS_STORE_DIR}/keystore.p12</value>"
@@ -83,10 +79,7 @@ mod tests {
 
     #[test]
     fn user_overrides_win_over_injected_defaults() {
-        let xml = build(
-            true,
-            config_overrides(&[("ssl.server.keystore.type", "jks")]),
-        );
+        let xml = build(true, [("ssl.server.keystore.type", "jks")].into());
         assert!(
             xml.contains("<name>ssl.server.keystore.type</name>\n    <value>jks</value>"),
             "{xml}"


### PR DESCRIPTION
## Description

Use KeyValueConfigOverrides with `BTreeMap<String, String>` from stackabletech/operator-rs#1219.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
