### PR TITLE
chore: Upgrade to stackable-operator 0.116.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ All notable changes to this project will be documented in this file.
 - The reconciler now applies resources and derives the cluster status in discrete
   apply and update_status steps ([#811]).
 - All product containers now run with `securityContext.runAsNonRoot` set to `true` to improve security ([#814]).
+- Bump stackable-operator to 0.116.0 ([#819]).
+- `envOverrides` names are now validated by the shared `EnvVarName` type when the HdfsCluster
+  resource is deserialized, rather than during reconciliation ([#819]).
+- The recommended labels are now built with the typed operator-rs `v2` label functions ([#819]).
+  The value of the `app.kubernetes.io/managed-by` label changes from `hdfs.stackable.tech_hdfs-operator-hdfs-controller`
+  to `hdfs.stackable.tech_hdfs-controller` on all managed resources, and the RBAC ServiceAccount and RoleBinding
+  are no longer created with the placeholder `app.kubernetes.io/component: none` and
+  `app.kubernetes.io/role-group: none` labels.
+  StatefulSet selectors and volume claim templates are unchanged, so upgrading is non-breaking.
 
 ### Fixed
 
@@ -26,6 +35,7 @@ All notable changes to this project will be documented in this file.
 [#810]: https://github.com/stackabletech/hdfs-operator/pull/810
 [#811]: https://github.com/stackabletech/hdfs-operator/pull/811
 [#814]: https://github.com/stackabletech/hdfs-operator/pull/814
+[#819]: https://github.com/stackabletech/hdfs-operator/pull/819
 
 ## [26.7.0] - 2026-07-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -316,9 +316,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9066c49992464636f92905fa096ec58baaa4d57ec19a5c096c68d3e25ef3d136"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -631,7 +631,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -910,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flagset"
@@ -959,9 +959,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -974,9 +974,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -984,15 +984,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1001,32 +1001,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-timer"
@@ -1036,9 +1036,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures 0.1.31",
  "futures-channel",
@@ -1154,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1236,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1366,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1380,9 +1380,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1393,9 +1393,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1407,16 +1407,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -1427,15 +1428,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1604,7 +1605,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -1653,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1672,7 +1673,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1685,7 +1686,7 @@ dependencies = [
  "pest_derive",
  "regex",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1714,7 +1715,7 @@ dependencies = [
 [[package]]
 name = "k8s-version"
 version = "0.1.3"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "darling 0.24.0",
  "regex",
@@ -1758,7 +1759,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "either",
- "futures 0.3.33",
+ "futures 0.3.34",
  "http",
  "http-body",
  "http-body-util",
@@ -1777,7 +1778,7 @@ dependencies = [
  "serde",
  "serde-saphyr",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tower",
@@ -1801,7 +1802,7 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1829,7 +1830,7 @@ dependencies = [
  "async-stream",
  "backon",
  "educe 0.6.0",
- "futures 0.3.33",
+ "futures 0.3.34",
  "hashbrown 0.16.1",
  "hostname",
  "json-patch",
@@ -1839,7 +1840,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1892,9 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -1998,9 +1999,9 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -2053,7 +2054,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -2095,7 +2096,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tonic",
  "tonic-types",
@@ -2133,7 +2134,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
 ]
@@ -2215,9 +2216,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -2225,9 +2226,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2235,9 +2236,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2248,9 +2249,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
 ]
@@ -2304,15 +2305,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -2325,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -2745,9 +2746,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3155,7 +3156,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stackable-certs"
 version = "0.4.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "const-oid",
  "ecdsa",
@@ -3184,7 +3185,7 @@ dependencies = [
  "built",
  "clap",
  "const_format",
- "futures 0.3.33",
+ "futures 0.3.34",
  "indoc",
  "rstest",
  "serde",
@@ -3200,8 +3201,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.115.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+version = "0.116.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "base64 0.23.1",
  "clap",
@@ -3210,7 +3211,7 @@ dependencies = [
  "dockerfile-parser",
  "educe 0.7.6",
  "either",
- "futures 0.3.33",
+ "futures 0.3.34",
  "http",
  "indexmap",
  "java-properties",
@@ -3245,7 +3246,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "darling 0.24.0",
  "proc-macro2",
@@ -3256,7 +3257,7 @@ dependencies = [
 [[package]]
 name = "stackable-shared"
 version = "0.1.2"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "jiff",
  "k8s-openapi",
@@ -3273,7 +3274,7 @@ dependencies = [
 [[package]]
 name = "stackable-telemetry"
 version = "0.6.5"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "axum",
  "clap",
@@ -3297,7 +3298,7 @@ dependencies = [
 [[package]]
 name = "stackable-versioned"
 version = "0.11.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "kube",
  "schemars",
@@ -3311,7 +3312,7 @@ dependencies = [
 [[package]]
 name = "stackable-versioned-macros"
 version = "0.11.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "convert_case",
  "convert_case_extras",
@@ -3329,7 +3330,7 @@ dependencies = [
 [[package]]
 name = "stackable-webhook"
 version = "0.9.2"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#fb2d86579f4e3df008f78f0e527a012243483a2d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#7b9f9ac9a76fa425ab27f2821377ef86571ca121"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3461,11 +3462,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -3481,9 +3482,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3531,9 +3532,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3792,7 +3793,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "tracing-subscriber",
 ]
@@ -3824,7 +3825,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "futures 0.3.33",
+ "futures 0.3.34",
  "futures-task",
  "pin-project",
  "tracing",
@@ -3969,9 +3970,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4031,9 +4032,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4044,9 +4045,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4054,9 +4055,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4064,9 +4065,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4077,18 +4078,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4280,9 +4281,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "x509-cert"
@@ -4390,9 +4391,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4401,9 +4402,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4412,13 +4413,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -489,9 +489,9 @@ rec {
       };
       "async-trait" = rec {
         crateName = "async-trait";
-        version = "0.1.91";
+        version = "0.1.92";
         edition = "2021";
-        sha256 = "1v3cm8mzg66037wm392p1vsdx0lq8bid6y2ivr7z03lpfx0xqdmf";
+        sha256 = "0rqn5iga1hlv2lm8xzav1zhar46jb4dvx89i6kfv93kb53maxxl2";
         procMacro = true;
         libName = "async_trait";
         authors = [
@@ -989,9 +989,9 @@ rec {
       };
       "cc" = rec {
         crateName = "cc";
-        version = "1.4.1";
+        version = "1.4.3";
         edition = "2021";
-        sha256 = "0dniydgf5lv8dh4mr6n1gvas9albqmp0kyh557wkcij6jacw8rlh";
+        sha256 = "0v9b5arr047vbihfbh3fmbd3aj9vf1i7dbdgfpvlwzynpjvr35ah";
         dependencies = [
           {
             name = "find-msvc-tools";
@@ -1903,7 +1903,7 @@ rec {
         dependencies = [
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
         ];
         features = {
@@ -2794,9 +2794,9 @@ rec {
       };
       "find-msvc-tools" = rec {
         crateName = "find-msvc-tools";
-        version = "0.1.10";
+        version = "0.1.11";
         edition = "2021";
-        sha256 = "1pp1612g5k6im9732g16j6a87czhb35xcyzlrpq2mkgdwrrkbdr6";
+        sha256 = "145qpfb9r4ml2klr8v4byvrkikp61qyiks9n69b8z0vbscbb0pfl";
         libName = "find_msvc_tools";
 
       };
@@ -2923,11 +2923,11 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" "use_std" "with-deprecated" ];
       };
-      "futures 0.3.33" = rec {
+      "futures 0.3.34" = rec {
         crateName = "futures";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "066j5aqz8an05xh4hn5ljdnjn80z3g335v4grx4gaifr57wg3358";
+        sha256 = "18yhwmbdalhz2z9i1vm10hy2v0cfm82dkgcb6vr2msxazfix4ccs";
         dependencies = [
           {
             name = "futures-channel";
@@ -2987,9 +2987,9 @@ rec {
       };
       "futures-channel" = rec {
         crateName = "futures-channel";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "1bn5hlhfkl1sgypmiachaqcgwmr6wmjal7dyhfyb1zkazvs90996";
+        sha256 = "1i4kwcanpaphn1ax62ci3nx176kglxqx0gnhzqpqdr1rkpbf7ydi";
         libName = "futures_channel";
         dependencies = [
           {
@@ -3015,9 +3015,9 @@ rec {
       };
       "futures-core" = rec {
         crateName = "futures-core";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "1iqdbvcdlplfr2g43h7xrfkv2sg5p1a26x8acz1xgxl07i3hrm9c";
+        sha256 = "0pjgv4fx0np6hrs5sz5a2phabwv0z70yr51v03injbi44bjrkmlj";
         libName = "futures_core";
         features = {
           "default" = [ "std" ];
@@ -3028,9 +3028,9 @@ rec {
       };
       "futures-executor" = rec {
         crateName = "futures-executor";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "0n3lpkmcfrsnh40i4armn040gnqbpd257hz5qs46zipjr6f8fm37";
+        sha256 = "0cjl3y7jgg60wwb96ikxj23r6q91ylvx8v675yychv1w3b7lf6q3";
         libName = "futures_executor";
         dependencies = [
           {
@@ -3058,9 +3058,9 @@ rec {
       };
       "futures-io" = rec {
         crateName = "futures-io";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "0yjx13qdm9b2p4w00ddw85k6yccnnmqrlrrz8yfmi5jg7jmfqxs5";
+        sha256 = "1v9z6wj92ra18kpv0xig21hgpzrvcwmcr8fszyzh64yyay0zmh2k";
         libName = "futures_io";
         features = {
           "default" = [ "std" ];
@@ -3069,9 +3069,9 @@ rec {
       };
       "futures-macro" = rec {
         crateName = "futures-macro";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "02xiyd5y1nk9b805aympj4wq2czgvxnhcml9w9xkc665d3g3qv9d";
+        sha256 = "0i0czvcvsqq4hrccibq2f23004si5z34zjwdxfmqhlrmm15nbfcz";
         procMacro = true;
         libName = "futures_macro";
         dependencies = [
@@ -3085,7 +3085,7 @@ rec {
           }
           {
             name = "syn";
-            packageId = "syn 2.0.119";
+            packageId = "syn 3.0.3";
             features = [ "full" ];
           }
         ];
@@ -3093,9 +3093,9 @@ rec {
       };
       "futures-sink" = rec {
         crateName = "futures-sink";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "01z38z344hpryw84b6r0rbwcb669d8pyvl2szg10aqwx96n1hi73";
+        sha256 = "07cfvrgc3vxk6sw5g8a8dnrm1mzg6d5mwy08ywa1sgyhyxml4i0r";
         libName = "futures_sink";
         features = {
           "default" = [ "std" ];
@@ -3105,9 +3105,9 @@ rec {
       };
       "futures-task" = rec {
         crateName = "futures-task";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "02f1y1yvjg1cv998zkgl1706pi9y4fyc9045l1hlmyqyhclfscdj";
+        sha256 = "1zfilqs8nwlfqz4prk7ihvpp5avvzins87ibzlxzq5fhs7ipshfd";
         libName = "futures_task";
         features = {
           "default" = [ "std" ];
@@ -3132,9 +3132,9 @@ rec {
       };
       "futures-util" = rec {
         crateName = "futures-util";
-        version = "0.3.33";
+        version = "0.3.34";
         edition = "2018";
-        sha256 = "1anyg40j5www5l22r2jbn1birsafz4q1w9qmcjk4vqzwasi90ym7";
+        sha256 = "1g3r9ghzq7c2fh34lis43i72xavk9p84npgfwgb5vfpqcwjajl0d";
         libName = "futures_util";
         dependencies = [
           {
@@ -3621,9 +3621,9 @@ rec {
       };
       "h2" = rec {
         crateName = "h2";
-        version = "0.4.15";
+        version = "0.4.16";
         edition = "2021";
-        sha256 = "0mgilh1g8gydcchqi6acs5l6j0gwg5jwpa64sj4b3ncb9v497c3c";
+        sha256 = "09syqqhvh36b3rwyn8vjhiz597hfki1hcz3hwagb3cs1ifapmwx9";
         authors = [
           "Carl Lerche <me@carllerche.com>"
           "Sean McArthur <sean@seanmonstar.com>"
@@ -3861,9 +3861,9 @@ rec {
       };
       "http-body-util" = rec {
         crateName = "http-body-util";
-        version = "0.1.4";
+        version = "0.1.5";
         edition = "2018";
-        sha256 = "1wizkqx9a75x8v5lm7cawpammz8sfvd7cngnkp34wkcfl3b1zx79";
+        sha256 = "07773iilap808wjp6vywlq15zkgwnswqzrv270zxvg2z9biry5i3";
         libName = "http_body_util";
         authors = [
           "Carl Lerche <me@carllerche.com>"
@@ -4371,9 +4371,9 @@ rec {
       };
       "icu_collections" = rec {
         crateName = "icu_collections";
-        version = "2.2.0";
-        edition = "2021";
-        sha256 = "070r7xd0pynm0hnc1v2jzlbxka6wf50f81wybf9xg0y82v6x3119";
+        version = "2.3.0";
+        edition = "2024";
+        sha256 = "04x59h6vdq0cnpippim1nr471ivlsnnn470sj1d5v864h48d4s7s";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -4421,9 +4421,9 @@ rec {
       };
       "icu_locale_core" = rec {
         crateName = "icu_locale_core";
-        version = "2.2.0";
-        edition = "2021";
-        sha256 = "0a9cmin5w1x3bg941dlmgszn33qgq428k7qiqn5did72ndi9n8cj";
+        version = "2.3.0";
+        edition = "2024";
+        sha256 = "1sqdj16wwl7h9y6r7j394av4kpdb7zryz9h169ffwbm9imc2hvnm";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -4473,9 +4473,9 @@ rec {
       };
       "icu_normalizer" = rec {
         crateName = "icu_normalizer";
-        version = "2.2.0";
-        edition = "2021";
-        sha256 = "1d7krxr0xpc4x9635k1100a24nh0nrc59n65j6yk6gbfkplmwvn5";
+        version = "2.3.0";
+        edition = "2024";
+        sha256 = "0vv43ixk2wmbxrx7kl33cwkhx1wdyb1q3pa18qkyshan4dgwzy8j";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -4527,9 +4527,9 @@ rec {
       };
       "icu_normalizer_data" = rec {
         crateName = "icu_normalizer_data";
-        version = "2.2.0";
-        edition = "2021";
-        sha256 = "0f5d5d5fhhr9937m2z6z38fzh6agf14z24kwlr6lyczafypf0fys";
+        version = "2.3.0";
+        edition = "2024";
+        sha256 = "1811h0ppb7lwq1q2492p5x6lcmlwmhbmkf69fhyvzcz0scgdlqqm";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -4537,13 +4537,18 @@ rec {
       };
       "icu_properties" = rec {
         crateName = "icu_properties";
-        version = "2.2.0";
-        edition = "2021";
-        sha256 = "1pkh3s837808cbwxvfagwc28cvwrz2d9h5rl02jwrhm51ryvdqxy";
+        version = "2.3.0";
+        edition = "2024";
+        sha256 = "0j51hi8qgf0l6a7qzvnwsc61598w2fpnsklicld6ci9immva4z3y";
         authors = [
           "The ICU4X Project Developers"
         ];
         dependencies = [
+          {
+            name = "displaydoc";
+            packageId = "displaydoc";
+            usesDefaultFeatures = false;
+          }
           {
             name = "icu_collections";
             packageId = "icu_collections";
@@ -4585,6 +4590,7 @@ rec {
           "datagen" = [ "serde" "dep:databake" "zerovec/databake" "icu_collections/databake" "icu_locale_core/databake" "zerotrie/databake" "icu_provider/export" ];
           "default" = [ "compiled_data" ];
           "harfbuzz_traits" = [ "dep:harfbuzz-traits" ];
+          "log" = [ "dep:log" ];
           "serde" = [ "dep:serde" "icu_locale_core/serde" "zerovec/serde" "icu_collections/serde" "icu_provider/serde" "zerotrie/serde" ];
           "unicode_bidi" = [ "dep:unicode-bidi" ];
         };
@@ -4592,9 +4598,9 @@ rec {
       };
       "icu_properties_data" = rec {
         crateName = "icu_properties_data";
-        version = "2.2.0";
-        edition = "2021";
-        sha256 = "052awny0qwkbcbpd5jg2cd7vl5ry26pq4hz1nfsgf10c3qhbnawf";
+        version = "2.3.0";
+        edition = "2024";
+        sha256 = "1akw1gp5rcaiz377xzsnkx8f92qax4kh3lfn9y4rcjj6q4wg1475";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -4602,9 +4608,9 @@ rec {
       };
       "icu_provider" = rec {
         crateName = "icu_provider";
-        version = "2.2.0";
-        edition = "2021";
-        sha256 = "08dl8pxbwr8zsz4c5vphqb7xw0hykkznwi4rw7bk6pwb3krlr70k";
+        version = "2.3.0";
+        edition = "2024";
+        sha256 = "0a343jlrb7jlb20xv1airslzv63559wf38jihrx81bba39kyv9wj";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -5103,7 +5109,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
           {
             name = "windows-link";
@@ -5221,9 +5227,9 @@ rec {
       };
       "js-sys" = rec {
         crateName = "js-sys";
-        version = "0.3.103";
+        version = "0.3.104";
         edition = "2021";
-        sha256 = "00lib0b6hqmw56r2hjp7xrv730qacslirbkdlhvmi39zvgy4pd2k";
+        sha256 = "0fjsgady7wbv7bbyy6c8qhrd93bnx11qbl83l1g7bb9a4601030f";
         libName = "js_sys";
         authors = [
           "The wasm-bindgen Developers"
@@ -5283,7 +5289,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
         ];
         devDependencies = [
@@ -5332,7 +5338,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
         ];
 
@@ -5430,8 +5436,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         libName = "k8s_version";
         authors = [
@@ -5609,7 +5615,7 @@ rec {
           }
           {
             name = "futures";
-            packageId = "futures 0.3.33";
+            packageId = "futures 0.3.34";
             optional = true;
             usesDefaultFeatures = false;
             features = [ "std" ];
@@ -5709,7 +5715,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
           {
             name = "tokio";
@@ -5745,7 +5751,7 @@ rec {
         devDependencies = [
           {
             name = "futures";
-            packageId = "futures 0.3.33";
+            packageId = "futures 0.3.34";
             usesDefaultFeatures = false;
             features = [ "async-await" ];
           }
@@ -5875,7 +5881,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
         ];
         devDependencies = [
@@ -5982,7 +5988,7 @@ rec {
           }
           {
             name = "futures";
-            packageId = "futures 0.3.33";
+            packageId = "futures 0.3.34";
             usesDefaultFeatures = false;
             features = [ "async-await" ];
           }
@@ -6027,7 +6033,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
           {
             name = "tokio";
@@ -6206,9 +6212,9 @@ rec {
       };
       "litemap" = rec {
         crateName = "litemap";
-        version = "0.8.2";
+        version = "0.8.3";
         edition = "2021";
-        sha256 = "1w7628bc7wwcxc4n4s5kw0610xk06710nh2hn5kwwk2wa91z9nlj";
+        sha256 = "1bpgpj87560hmckh3875fbahpmfxbk4g8pzns84h3ykf3nfx3na7";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -6526,9 +6532,9 @@ rec {
       };
       "num-integer" = rec {
         crateName = "num-integer";
-        version = "0.1.46";
+        version = "0.1.47";
         edition = "2018";
-        sha256 = "13w5g54a9184cqlbsq80rnxw4jj4s0d8wv75jsq5r2lms8gncsbr";
+        sha256 = "02z1p3azy6p10n99skrab4a6hhfd4amf2i9gm8sxqd1p9dfxkqkw";
         libName = "num_integer";
         authors = [
           "The Rust Project Developers"
@@ -6670,7 +6676,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
             optional = true;
             usesDefaultFeatures = false;
           }
@@ -6840,7 +6846,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
             usesDefaultFeatures = false;
           }
           {
@@ -7047,7 +7053,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
             usesDefaultFeatures = false;
           }
           {
@@ -7348,9 +7354,9 @@ rec {
       };
       "pest" = rec {
         crateName = "pest";
-        version = "2.8.8";
+        version = "2.9.0";
         edition = "2021";
-        sha256 = "18jhl2zpxvl6kikc0jgp7gi7i7cy9s634z5bnvx70w1whjz2ixvx";
+        sha256 = "1kwvhc5hyrfpxpmp0jw0wr891xyjs44mcs2wz68hrl54qw6ac1ss";
         authors = [
           "Dragoș Tiselice <dragostiselice@gmail.com>"
         ];
@@ -7377,9 +7383,9 @@ rec {
       };
       "pest_derive" = rec {
         crateName = "pest_derive";
-        version = "2.8.8";
+        version = "2.9.0";
         edition = "2021";
-        sha256 = "1zcijlfdf6sk2s6l1qnm3j7kj7d4ymqcial8w4p4dcr67gydcbcy";
+        sha256 = "13f8ihi8928s9mc13pcbhxy382kqc89h7i8d7s5mnif8lm23ga5k";
         procMacro = true;
         authors = [
           "Dragoș Tiselice <dragostiselice@gmail.com>"
@@ -7405,9 +7411,9 @@ rec {
       };
       "pest_generator" = rec {
         crateName = "pest_generator";
-        version = "2.8.8";
+        version = "2.9.0";
         edition = "2021";
-        sha256 = "1dkmk6r6bb2hh5wayymfmwd7mswwbyhw12dnx2lrdxdnrw2r4yka";
+        sha256 = "0jihcdnmdban4bqjd02r2wbb79nywj2nhwqyk95hvrixm98k9kg0";
         authors = [
           "Dragoș Tiselice <dragostiselice@gmail.com>"
         ];
@@ -7443,9 +7449,9 @@ rec {
       };
       "pest_meta" = rec {
         crateName = "pest_meta";
-        version = "2.8.8";
+        version = "2.9.0";
         edition = "2021";
-        sha256 = "0z7m54jc3nj3nxbbk4kyjfa06d8s24vhf6krzj2867nyq18x7aw5";
+        sha256 = "15jly0r7r4m15fhm3pg814h65j7dqnqq6k43rvgxfhg29443lkg0";
         authors = [
           "Dragoș Tiselice <dragostiselice@gmail.com>"
         ];
@@ -7576,9 +7582,9 @@ rec {
       };
       "pkg-config" = rec {
         crateName = "pkg-config";
-        version = "0.3.33";
-        edition = "2018";
-        sha256 = "17jnqmcbxsnwhg9gjf0nh6dj5k0x3hgwi3mb9krjnmfa9v435w8r";
+        version = "0.3.34";
+        edition = "2021";
+        sha256 = "0j05h08nzg0q8rf6lzw7nry0b7kn7x97vc9n4hwrl52fqzxn9d7n";
         libName = "pkg_config";
         authors = [
           "Alex Crichton <alex@alexcrichton.com>"
@@ -7587,9 +7593,9 @@ rec {
       };
       "portable-atomic" = rec {
         crateName = "portable-atomic";
-        version = "1.14.0";
+        version = "1.15.0";
         edition = "2018";
-        sha256 = "1hyfma9n2cs2ibazpfwrbv61zwg7cv86g0pr5yjkg07qgr4xa81x";
+        sha256 = "11csag858ndk5w4yz17h91vy53ynh67r2903gwwdn2cnilzbdj05";
         libName = "portable_atomic";
         features = {
           "critical-section" = [ "dep:critical-section" ];
@@ -7620,9 +7626,9 @@ rec {
       };
       "potential_utf" = rec {
         crateName = "potential_utf";
-        version = "0.1.5";
+        version = "0.1.6";
         edition = "2021";
-        sha256 = "0r0518fr32xbkgzqap509s3r60cr0iancsg9j1jgf37cyz7b20q1";
+        sha256 = "0qbndl2fpphq7mph41m11vaixs05xrh1s451wxlgap4fdnybjgnq";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -9090,9 +9096,9 @@ rec {
       };
       "rustls-webpki" = rec {
         crateName = "rustls-webpki";
-        version = "0.103.13";
+        version = "0.103.14";
         edition = "2021";
-        sha256 = "0vkm7z9pnxz5qz66p2kmyy2pwx0g4jnsbqk5xzfhs4czcjl2ki31";
+        sha256 = "0njk28gvbqrsfg1b5r35y4f80n37kcjylj72fpc0k0g60n3529q5";
         libName = "webpki";
         dependencies = [
           {
@@ -9116,7 +9122,7 @@ rec {
           "alloc" = [ "ring?/alloc" "pki-types/alloc" ];
           "aws-lc-rs" = [ "dep:aws-lc-rs" "aws-lc-rs/aws-lc-sys" "aws-lc-rs/prebuilt-nasm" ];
           "aws-lc-rs-fips" = [ "dep:aws-lc-rs" "aws-lc-rs/fips" ];
-          "aws-lc-rs-unstable" = [ "aws-lc-rs" "aws-lc-rs/unstable" ];
+          "aws-lc-rs-unstable" = [ "aws-lc-rs" ];
           "default" = [ "std" ];
           "ring" = [ "dep:ring" ];
           "std" = [ "alloc" "pki-types/std" ];
@@ -10328,8 +10334,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         libName = "stackable_certs";
         authors = [
@@ -10454,7 +10460,7 @@ rec {
           }
           {
             name = "futures";
-            packageId = "futures 0.3.33";
+            packageId = "futures 0.3.34";
             features = [ "compat" ];
           }
           {
@@ -10520,13 +10526,13 @@ rec {
       };
       "stackable-operator" = rec {
         crateName = "stackable-operator";
-        version = "0.115.0";
+        version = "0.116.0";
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         libName = "stackable_operator";
         authors = [
@@ -10566,7 +10572,7 @@ rec {
           }
           {
             name = "futures";
-            packageId = "futures 0.3.33";
+            packageId = "futures 0.3.34";
           }
           {
             name = "http";
@@ -10706,7 +10712,8 @@ rec {
           "client-feature-gates" = [ "dep:winnow" ];
           "crds" = [ "dep:stackable-versioned" ];
           "default" = [ "crds" ];
-          "full" = [ "client-feature-gates" "crds" "certs" "test-support" "time" "webhook" "kube-ws" ];
+          "full" = [ "client-feature-gates" "crds" "certs" "test-support" "time" "webhook" "kube-ws" "kube-cel" ];
+          "kube-cel" = [ "kube/cel" ];
           "kube-ws" = [ "kube/ws" ];
           "time" = [ "stackable-shared/time" ];
           "webhook" = [ "dep:stackable-webhook" ];
@@ -10720,8 +10727,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         procMacro = true;
         libName = "stackable_operator_derive";
@@ -10755,8 +10762,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         libName = "stackable_shared";
         authors = [
@@ -10836,8 +10843,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         libName = "stackable_telemetry";
         authors = [
@@ -10946,8 +10953,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         libName = "stackable_versioned";
         authors = [
@@ -10996,8 +11003,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         procMacro = true;
         libName = "stackable_versioned_macros";
@@ -11064,8 +11071,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "fb2d86579f4e3df008f78f0e527a012243483a2d";
-          sha256 = "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb";
+          rev = "7b9f9ac9a76fa425ab27f2821377ef86571ca121";
+          sha256 = "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9";
         };
         libName = "stackable_webhook";
         authors = [
@@ -11447,18 +11454,18 @@ rec {
         ];
 
       };
-      "thiserror 2.0.19" = rec {
+      "thiserror 2.0.20" = rec {
         crateName = "thiserror";
-        version = "2.0.19";
+        version = "2.0.20";
         edition = "2021";
-        sha256 = "1ngwxsjsa64v1n7vb90h2b0i3fqk1piwaf0z6fqdacqfhjc3b909";
+        sha256 = "0kxs6p295jffxhzaxpxv1dwaaf5iqlm6sx8h0djp6ancbxgj71pc";
         authors = [
           "David Tolnay <dtolnay@gmail.com>"
         ];
         dependencies = [
           {
             name = "thiserror-impl";
-            packageId = "thiserror-impl 2.0.19";
+            packageId = "thiserror-impl 2.0.20";
           }
         ];
         features = {
@@ -11492,11 +11499,11 @@ rec {
         ];
 
       };
-      "thiserror-impl 2.0.19" = rec {
+      "thiserror-impl 2.0.20" = rec {
         crateName = "thiserror-impl";
-        version = "2.0.19";
+        version = "2.0.20";
         edition = "2021";
-        sha256 = "1ka10pqy1g8zy5al9m8yadg30jp8hx0q80j8awmd8131yw6gxjs3";
+        sha256 = "1bwjc94gi0xn5jz26h1a8bjj1wdkvvr6jifamyc4mp9n28zcs15w";
         procMacro = true;
         libName = "thiserror_impl";
         authors = [
@@ -11645,9 +11652,9 @@ rec {
       };
       "tinystr" = rec {
         crateName = "tinystr";
-        version = "0.8.3";
+        version = "0.8.4";
         edition = "2021";
-        sha256 = "0vfr8x285w6zsqhna0a9jyhylwiafb2kc8pj2qaqaahw48236cn8";
+        sha256 = "0hzncw8rgk4syla79qscfml46jm7ll1zdp7kdacc42cj8n8prqmi";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -12728,7 +12735,7 @@ rec {
           }
           {
             name = "thiserror";
-            packageId = "thiserror 2.0.19";
+            packageId = "thiserror 2.0.20";
           }
           {
             name = "time";
@@ -12822,7 +12829,7 @@ rec {
         dependencies = [
           {
             name = "futures";
-            packageId = "futures 0.3.33";
+            packageId = "futures 0.3.34";
             optional = true;
           }
           {
@@ -13310,9 +13317,9 @@ rec {
       };
       "uuid" = rec {
         crateName = "uuid";
-        version = "1.24.0";
+        version = "1.24.1";
         edition = "2021";
-        sha256 = "0faj5x0zgri8m3i8dv9qgyhiwqwdyhbl2g351cp3iin4ynk26fdz";
+        sha256 = "1n8b7fg7dbx6ws64387l2i0qq900rw9b7qax63acdh37sczw1vrc";
         authors = [
           "Ashley Mannix<ashleymannix@live.com.au>"
           "Dylan DPC<dylan.dpc@gmail.com>"
@@ -13476,9 +13483,9 @@ rec {
       };
       "wasm-bindgen" = rec {
         crateName = "wasm-bindgen";
-        version = "0.2.126";
+        version = "0.2.127";
         edition = "2021";
-        sha256 = "197rma4qg1kb8l4bl7857pgszzval8s1w740g9myyjh92467q1jb";
+        sha256 = "0w6fa1mkbb6qlkffgy4qaz0hdf496zbjkyiyvs4lvmpd8xbr6w0v";
         libName = "wasm_bindgen";
         authors = [
           "The wasm-bindgen Developers"
@@ -13527,9 +13534,9 @@ rec {
       };
       "wasm-bindgen-futures" = rec {
         crateName = "wasm-bindgen-futures";
-        version = "0.4.76";
+        version = "0.4.77";
         edition = "2021";
-        sha256 = "0799v92cpaprapnmpaflc51sdnz362q2fsjdqnwiq8ij1wsg2bf6";
+        sha256 = "0l3r8m335kb2p8yj65kb0biwlypcx3ay4g750hafkl13rkapfxvb";
         libName = "wasm_bindgen_futures";
         authors = [
           "The wasm-bindgen Developers"
@@ -13555,9 +13562,9 @@ rec {
       };
       "wasm-bindgen-macro" = rec {
         crateName = "wasm-bindgen-macro";
-        version = "0.2.126";
+        version = "0.2.127";
         edition = "2021";
-        sha256 = "1cda6wl5zyiy7777cfgrix7fhpaqba55l5zpqj4zig7ng7jyaz0n";
+        sha256 = "1hcvlb6bv771fvgifd367wd0cm4giyar8fq5i4h705vj7y7myxvp";
         procMacro = true;
         libName = "wasm_bindgen_macro";
         authors = [
@@ -13579,9 +13586,9 @@ rec {
       };
       "wasm-bindgen-macro-support" = rec {
         crateName = "wasm-bindgen-macro-support";
-        version = "0.2.126";
+        version = "0.2.127";
         edition = "2021";
-        sha256 = "03iq412frl2py55skwb3ya08xha0cf6q22zr5kqlwbr675w7r6gk";
+        sha256 = "112j4d7dv8y2sk9yy9czrl9fpjx9388ywnn7icdv2bywazw367g1";
         libName = "wasm_bindgen_macro_support";
         authors = [
           "The wasm-bindgen Developers"
@@ -13615,10 +13622,10 @@ rec {
       };
       "wasm-bindgen-shared" = rec {
         crateName = "wasm-bindgen-shared";
-        version = "0.2.126";
+        version = "0.2.127";
         edition = "2021";
         links = "wasm_bindgen";
-        sha256 = "097a3kbjls447s1lwr41l21x5crrh5vq3h6zsxccz7slrjq4q6yw";
+        sha256 = "1gywp6xv8a27fvm3ga9xby93xyic3hc2s626b9z9rw2xqny4vxky";
         libName = "wasm_bindgen_shared";
         authors = [
           "The wasm-bindgen Developers"
@@ -13633,9 +13640,9 @@ rec {
       };
       "web-sys" = rec {
         crateName = "web-sys";
-        version = "0.3.103";
+        version = "0.3.104";
         edition = "2021";
-        sha256 = "0hb1zdnrp99p5r5q66jagsddmwha460yv2wklvzrzk0b3jvdq8l6";
+        sha256 = "0c0acbvaqzqf21q5vdff2g74fvb7afi91xjplmclybq4d24k6df4";
         libName = "web_sys";
         authors = [
           "The wasm-bindgen Developers"
@@ -13891,6 +13898,10 @@ rec {
           "MouseEvent" = [ "Event" "UiEvent" ];
           "MouseScrollEvent" = [ "Event" "MouseEvent" "UiEvent" ];
           "MutationEvent" = [ "Event" ];
+          "NavigateEvent" = [ "Event" ];
+          "Navigation" = [ "EventTarget" ];
+          "NavigationCurrentEntryChangeEvent" = [ "Event" ];
+          "NavigationHistoryEntry" = [ "EventTarget" ];
           "NetworkInformation" = [ "EventTarget" ];
           "Node" = [ "EventTarget" ];
           "Notification" = [ "EventTarget" ];
@@ -15013,9 +15024,9 @@ rec {
       };
       "writeable" = rec {
         crateName = "writeable";
-        version = "0.6.3";
+        version = "0.6.4";
         edition = "2021";
-        sha256 = "1i54d13h9bpap2hf13xcry1s4lxh7ap3923g8f3c0grd7c9fbyhz";
+        sha256 = "1p3r4s4wbf3dksfpj3xyrn7id5p0f7r74mj6qx6ngjfd6cm2vn1s";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -15325,9 +15336,9 @@ rec {
       };
       "zerotrie" = rec {
         crateName = "zerotrie";
-        version = "0.2.4";
+        version = "0.2.5";
         edition = "2021";
-        sha256 = "1gr0pkcn3qsr6in6iixqyp0vbzwf2j1jzyvh7yl2yydh3p9m548g";
+        sha256 = "0gss16krjzk22m57dz5hkdjg99ibj6pa41qr68na7w1jpp1nk8jf";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -15365,9 +15376,9 @@ rec {
       };
       "zerovec" = rec {
         crateName = "zerovec";
-        version = "0.11.6";
+        version = "0.11.7";
         edition = "2021";
-        sha256 = "0fdjsy6b31q9i0d73sl7xjd12xadbwi45lkpfgqnmasrqg5i3ych";
+        sha256 = "1n4n109wgbbin5hljq6gmbnqqg74yp9igzf40gbw2rkdjyswddcl";
         authors = [
           "The ICU4X Project Developers"
         ];
@@ -15411,9 +15422,9 @@ rec {
       };
       "zerovec-derive" = rec {
         crateName = "zerovec-derive";
-        version = "0.11.3";
+        version = "0.11.5";
         edition = "2021";
-        sha256 = "0m85qj92mmfvhjra6ziqky5b1p4kcmp5069k7kfadp5hr8jw8pb2";
+        sha256 = "1a8pz516ddcgxvxq3j1xgprac5wnprlrbyzsgzarj0423la2l8cz";
         procMacro = true;
         libName = "zerovec_derive";
         authors = [
@@ -15430,7 +15441,7 @@ rec {
           }
           {
             name = "syn";
-            packageId = "syn 2.0.119";
+            packageId = "syn 3.0.3";
             features = [ "extra-traits" ];
           }
         ];

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2024"
 repository = "https://github.com/stackabletech/hdfs-operator"
 
 [workspace.dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.115.0", features = ["crds", "webhook"] }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.116.0", features = ["crds", "webhook"] }
 
 anyhow = "1.0"
 built = { version = "0.8", features = ["chrono", "git2"] }

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,11 +1,11 @@
 {
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#k8s-version@0.1.3": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-certs@0.4.1": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-operator-derive@0.3.1": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-operator@0.115.0": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-shared@0.1.2": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-telemetry@0.6.5": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-versioned-macros@0.11.1": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-versioned@0.11.1": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.115.0#stackable-webhook@0.9.2": "1w57n5xx0ik63r252l1v5ymm51jlsf7v4pj682b902k8vinlhyqb"
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#k8s-version@0.1.3": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-certs@0.4.1": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-operator-derive@0.3.1": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-operator@0.116.0": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-shared@0.1.2": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-telemetry@0.6.5": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-versioned-macros@0.11.1": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-versioned@0.11.1": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.116.0#stackable-webhook@0.9.2": "1p3744fxgvs12sqwvi8hhainwrgvhdfwmbyqf0sp0aq3awq3q1v9"
 }

--- a/deploy/helm/chart_testing.yaml
+++ b/deploy/helm/chart_testing.yaml
@@ -1,3 +1,4 @@
+---
 remote: origin
 target-branch: main
 chart-dirs:

--- a/deploy/helm/chart_testing.yaml
+++ b/deploy/helm/chart_testing.yaml
@@ -1,4 +1,3 @@
----
 remote: origin
 target-branch: main
 chart-dirs:

--- a/extra/crds.yaml
+++ b/extra/crds.yaml
@@ -660,7 +660,8 @@ spec:
                     default: {}
                     description: |-
                       `envOverrides` configure environment variables to be set in the Pods.
-                      It is a map from strings to strings - environment variables and the value to set.
+                      It is a map from environment variable names to their values. The names are validated to be
+                      valid environment variable names.
                       Read the
                       [environment variable overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#env-overrides)
                       for more information and consult the operator specific usage guide to find out about
@@ -1226,7 +1227,8 @@ spec:
                           default: {}
                           description: |-
                             `envOverrides` configure environment variables to be set in the Pods.
-                            It is a map from strings to strings - environment variables and the value to set.
+                            It is a map from environment variable names to their values. The names are validated to be
+                            valid environment variable names.
                             Read the
                             [environment variable overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#env-overrides)
                             for more information and consult the operator specific usage guide to find out about
@@ -1750,7 +1752,8 @@ spec:
                     default: {}
                     description: |-
                       `envOverrides` configure environment variables to be set in the Pods.
-                      It is a map from strings to strings - environment variables and the value to set.
+                      It is a map from environment variable names to their values. The names are validated to be
+                      valid environment variable names.
                       Read the
                       [environment variable overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#env-overrides)
                       for more information and consult the operator specific usage guide to find out about
@@ -2216,7 +2219,8 @@ spec:
                           default: {}
                           description: |-
                             `envOverrides` configure environment variables to be set in the Pods.
-                            It is a map from strings to strings - environment variables and the value to set.
+                            It is a map from environment variable names to their values. The names are validated to be
+                            valid environment variable names.
                             Read the
                             [environment variable overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#env-overrides)
                             for more information and consult the operator specific usage guide to find out about
@@ -2926,7 +2930,8 @@ spec:
                     default: {}
                     description: |-
                       `envOverrides` configure environment variables to be set in the Pods.
-                      It is a map from strings to strings - environment variables and the value to set.
+                      It is a map from environment variable names to their values. The names are validated to be
+                      valid environment variable names.
                       Read the
                       [environment variable overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#env-overrides)
                       for more information and consult the operator specific usage guide to find out about
@@ -3641,7 +3646,8 @@ spec:
                           default: {}
                           description: |-
                             `envOverrides` configure environment variables to be set in the Pods.
-                            It is a map from strings to strings - environment variables and the value to set.
+                            It is a map from environment variable names to their values. The names are validated to be
+                            valid environment variable names.
                             Read the
                             [environment variable overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#env-overrides)
                             for more information and consult the operator specific usage guide to find out about

--- a/rust/operator-binary/src/controller/apply.rs
+++ b/rust/operator-binary/src/controller/apply.rs
@@ -16,8 +16,8 @@ use strum::{EnumDiscriminants, IntoStaticStr};
 
 use crate::{
     controller::{
-        Applied, KubernetesResources, Prepared, ValidatedCluster, controller_name, operator_name,
-        product_name,
+        Applied, CONTROLLER_NAME, KubernetesResources, OPERATOR_NAME, PRODUCT_NAME, Prepared,
+        ValidatedCluster,
     },
     crd::UpgradeState,
 };
@@ -72,9 +72,9 @@ impl<'a> Applier<'a> {
         object_overrides: &'a ObjectOverrides,
     ) -> Applier<'a> {
         let cluster_resources = cluster_resources_new(
-            &product_name(),
-            &operator_name(),
-            &controller_name(),
+            &PRODUCT_NAME,
+            &OPERATOR_NAME,
+            &CONTROLLER_NAME,
             &cluster.name,
             &cluster.namespace,
             &cluster.uid,

--- a/rust/operator-binary/src/controller/build/container.rs
+++ b/rust/operator-binary/src/controller/build/container.rs
@@ -637,6 +637,7 @@ impl ContainerConfig {
                 {create_vector_shutdown_file_command}
                 "#,
                     hadoop_home = Self::HADOOP_HOME,
+                    role = role.as_ref(),
                     remove_vector_shutdown_file_command =
                         remove_vector_shutdown_file_command(STACKABLE_LOG_DIR),
                     create_vector_shutdown_file_command =
@@ -1500,10 +1501,22 @@ impl ContainerVolumeDirs {
 impl From<HdfsNodeRole> for ContainerVolumeDirs {
     fn from(role: HdfsNodeRole) -> Self {
         ContainerVolumeDirs {
-            final_config_dir: format!("{base}/{role}", base = Self::NODE_BASE_CONFIG_DIR),
-            config_mount: format!("{base}/{role}", base = Self::NODE_BASE_CONFIG_DIR_MOUNT),
+            final_config_dir: format!(
+                "{base}/{role}",
+                base = Self::NODE_BASE_CONFIG_DIR,
+                role = role.as_ref()
+            ),
+            config_mount: format!(
+                "{base}/{role}",
+                base = Self::NODE_BASE_CONFIG_DIR_MOUNT,
+                role = role.as_ref()
+            ),
             config_mount_name: ContainerConfig::HDFS_CONFIG_VOLUME_MOUNT_NAME.to_string(),
-            log_mount: format!("{base}/{role}", base = Self::NODE_BASE_LOG_DIR_MOUNT),
+            log_mount: format!(
+                "{base}/{role}",
+                base = Self::NODE_BASE_LOG_DIR_MOUNT,
+                role = role.as_ref()
+            ),
             log_mount_name: ContainerConfig::HDFS_LOG_VOLUME_MOUNT_NAME.to_string(),
         }
     }
@@ -1512,10 +1525,22 @@ impl From<HdfsNodeRole> for ContainerVolumeDirs {
 impl From<&HdfsNodeRole> for ContainerVolumeDirs {
     fn from(role: &HdfsNodeRole) -> Self {
         ContainerVolumeDirs {
-            final_config_dir: format!("{base}/{role}", base = Self::NODE_BASE_CONFIG_DIR),
-            config_mount: format!("{base}/{role}", base = Self::NODE_BASE_CONFIG_DIR_MOUNT),
+            final_config_dir: format!(
+                "{base}/{role}",
+                base = Self::NODE_BASE_CONFIG_DIR,
+                role = role.as_ref()
+            ),
+            config_mount: format!(
+                "{base}/{role}",
+                base = Self::NODE_BASE_CONFIG_DIR_MOUNT,
+                role = role.as_ref()
+            ),
             config_mount_name: ContainerConfig::HDFS_CONFIG_VOLUME_MOUNT_NAME.to_string(),
-            log_mount: format!("{base}/{role}", base = Self::NODE_BASE_LOG_DIR_MOUNT),
+            log_mount: format!(
+                "{base}/{role}",
+                base = Self::NODE_BASE_LOG_DIR_MOUNT,
+                role = role.as_ref()
+            ),
             log_mount_name: ContainerConfig::HDFS_LOG_VOLUME_MOUNT_NAME.to_string(),
         }
     }

--- a/rust/operator-binary/src/controller/build/jvm.rs
+++ b/rust/operator-binary/src/controller/build/jvm.rs
@@ -78,7 +78,7 @@ pub fn construct_role_specific_jvm_args(
             "-Djava.security.properties={config_dir}/{}",
             ConfigFileName::Security
         ),
-        format!("-javaagent:/stackable/jmx/jmx_prometheus_javaagent.jar={metrics_port}:/stackable/jmx/{hdfs_role}.yaml")
+        format!("-javaagent:/stackable/jmx/jmx_prometheus_javaagent.jar={metrics_port}:/stackable/jmx/{hdfs_role}.yaml", hdfs_role = hdfs_role.as_ref())
     ]);
     if kerberos_enabled {
         jvm_args.push(format!(

--- a/rust/operator-binary/src/controller/build/mod.rs
+++ b/rust/operator-binary/src/controller/build/mod.rs
@@ -7,21 +7,26 @@ use stackable_operator::{
     utils::cluster_info::KubernetesClusterInfo,
     v2::{
         builder::meta::ownerreference_from_resource,
-        types::{common::Port, operator::RoleGroupName},
+        kvp::label,
+        types::{
+            common::Port,
+            operator::{RoleGroupName, RoleName},
+        },
     },
 };
 
 use crate::{
     controller::{
-        KubernetesResources, Prepared, ValidatedCluster,
+        CONTROLLER_NAME, KubernetesResources, OPERATOR_NAME, PRODUCT_NAME, Prepared,
+        ValidatedCluster,
         build::resource::rbac::{build_role_binding, build_service_account},
     },
     crd::{
         HdfsNodeRole, HdfsPodRef,
         constants::{
-            APP_NAME, DEFAULT_DATA_NODE_DATA_PORT, DEFAULT_DATA_NODE_HTTP_PORT,
-            DEFAULT_DATA_NODE_HTTPS_PORT, DEFAULT_DATA_NODE_IPC_PORT,
-            DEFAULT_DATA_NODE_METRICS_PORT, DEFAULT_DATA_NODE_NATIVE_METRICS_HTTP_PORT,
+            DEFAULT_DATA_NODE_DATA_PORT, DEFAULT_DATA_NODE_HTTP_PORT, DEFAULT_DATA_NODE_HTTPS_PORT,
+            DEFAULT_DATA_NODE_IPC_PORT, DEFAULT_DATA_NODE_METRICS_PORT,
+            DEFAULT_DATA_NODE_NATIVE_METRICS_HTTP_PORT,
             DEFAULT_DATA_NODE_NATIVE_METRICS_HTTPS_PORT, DEFAULT_JOURNAL_NODE_HTTP_PORT,
             DEFAULT_JOURNAL_NODE_HTTPS_PORT, DEFAULT_JOURNAL_NODE_METRICS_PORT,
             DEFAULT_JOURNAL_NODE_NATIVE_METRICS_HTTP_PORT,
@@ -46,21 +51,21 @@ pub mod resource;
 
 #[derive(Snafu, Debug)]
 pub enum Error {
-    #[snafu(display("failed to build Service for role {role} role group {role_group}"))]
+    #[snafu(display("failed to build Service for role {role} role group {role_group}", role = role.as_ref()))]
     Service {
         source: resource::service::Error,
         role: HdfsNodeRole,
         role_group: RoleGroupName,
     },
 
-    #[snafu(display("failed to build ConfigMap for role {role} role group {role_group}"))]
+    #[snafu(display("failed to build ConfigMap for role {role} role group {role_group}", role = role.as_ref()))]
     ConfigMap {
         source: resource::config_map::Error,
         role: HdfsNodeRole,
         role_group: RoleGroupName,
     },
 
-    #[snafu(display("failed to build StatefulSet for role {role} role group {role_group}"))]
+    #[snafu(display("failed to build StatefulSet for role {role} role group {role_group}", role = role.as_ref()))]
     StatefulSet {
         source: resource::statefulset::Error,
         role: HdfsNodeRole,
@@ -230,7 +235,7 @@ pub(crate) fn rolegroup_metadata(
             .role_group_resource_names(role, role_group_name)
             .qualified_role_group_name()
             .to_string(),
-        cluster.recommended_labels(role, role_group_name),
+        recommended_labels_for_role_group_resources(cluster, role, role_group_name),
     )
 }
 
@@ -241,10 +246,8 @@ pub(crate) fn rolegroup_selector_labels(
     role: &HdfsNodeRole,
     role_group_name: &RoleGroupName,
 ) -> Result<Labels, LabelError> {
-    let role_name = role.to_string();
-    let mut group_labels =
-        Labels::role_group_selector(cluster, APP_NAME, &role_name, role_group_name.as_ref())?;
-    group_labels.parse_insert(("role", &role_name))?;
+    let mut group_labels = role_group_selector(cluster, role, role_group_name);
+    group_labels.parse_insert(("role", role.as_ref()))?;
     group_labels.parse_insert(("group", role_group_name.as_ref()))?;
 
     Ok(group_labels)
@@ -376,6 +379,55 @@ fn role_data_ports(role: &HdfsNodeRole, https_enabled: bool) -> Vec<(String, Por
             },
         ],
     }
+}
+
+pub(crate) fn recommended_labels_for_cluster_resources(cluster: &ValidatedCluster) -> Labels {
+    label::recommended_labels_for_cluster_resources(
+        &cluster.name,
+        &PRODUCT_NAME,
+        &cluster.product_version,
+        &OPERATOR_NAME,
+        &CONTROLLER_NAME,
+    )
+}
+
+pub(crate) fn recommended_labels_for_role_resources(
+    cluster: &ValidatedCluster,
+    role_name: &RoleName,
+) -> Labels {
+    label::recommended_labels_for_role_resources(
+        &cluster.name,
+        &PRODUCT_NAME,
+        &cluster.product_version,
+        &OPERATOR_NAME,
+        &CONTROLLER_NAME,
+        role_name,
+    )
+}
+
+pub(crate) fn recommended_labels_for_role_group_resources(
+    cluster: &ValidatedCluster,
+    role_name: &RoleName,
+    role_group_name: &RoleGroupName,
+) -> Labels {
+    label::recommended_labels_for_role_group_resources(
+        &cluster.name,
+        &PRODUCT_NAME,
+        &cluster.product_version,
+        &OPERATOR_NAME,
+        &CONTROLLER_NAME,
+        role_name,
+        role_group_name,
+    )
+}
+
+/// Selector labels matching the pods of a role group.
+pub(crate) fn role_group_selector(
+    cluster: &ValidatedCluster,
+    role_name: &RoleName,
+    role_group_name: &RoleGroupName,
+) -> Labels {
+    label::role_group_selector(&cluster.name, &PRODUCT_NAME, role_name, role_group_name)
 }
 
 #[cfg(test)]

--- a/rust/operator-binary/src/controller/build/resource/config_map.rs
+++ b/rust/operator-binary/src/controller/build/resource/config_map.rs
@@ -50,7 +50,10 @@ pub fn build_rolegroup_config_map(
     role: &HdfsNodeRole,
     role_group_name: &RoleGroupName,
 ) -> Result<ConfigMap> {
-    tracing::info!("Setting up ConfigMap for role {role} role group {role_group_name}");
+    tracing::info!(
+        "Setting up ConfigMap for role {role} role group {role_group_name}",
+        role = (**role).clone()
+    );
 
     let metadata = build::rolegroup_metadata(cluster, role, role_group_name);
 

--- a/rust/operator-binary/src/controller/build/resource/config_map.rs
+++ b/rust/operator-binary/src/controller/build/resource/config_map.rs
@@ -52,7 +52,7 @@ pub fn build_rolegroup_config_map(
 ) -> Result<ConfigMap> {
     tracing::info!(
         "Setting up ConfigMap for role {role} role group {role_group_name}",
-        role = (**role).clone()
+        role = role.as_ref()
     );
 
     let metadata = build::rolegroup_metadata(cluster, role, role_group_name);

--- a/rust/operator-binary/src/controller/build/resource/discovery.rs
+++ b/rust/operator-binary/src/controller/build/resource/discovery.rs
@@ -1,13 +1,11 @@
 //! Build the discovery `ConfigMap` for the HdfsCluster.
 
-use std::str::FromStr;
-
 use snafu::{ResultExt, Snafu};
 use stackable_operator::{
     builder::{configmap::ConfigMapBuilder, meta::ObjectMetaBuilder},
     k8s_openapi::api::core::v1::ConfigMap,
     utils::cluster_info::KubernetesClusterInfo,
-    v2::types::operator::{ClusterName, RoleGroupName},
+    v2::types::operator::ClusterName,
 };
 
 use crate::{
@@ -19,14 +17,13 @@ use crate::{
             properties::{
                 ConfigFileName, core_site::CoreSiteConfigBuilder, hdfs_site::HdfsSiteConfigBuilder,
             },
+            recommended_labels_for_role_resources,
         },
     },
     crd::{HdfsNodeRole, HdfsPodRef, namenode_listener_refs},
 };
 
 type Result<T, E = Error> = std::result::Result<T, E>;
-
-stackable_operator::constant!(DISCOVERY_ROLE_GROUP: RoleGroupName = "discovery");
 
 #[derive(Snafu, Debug)]
 pub enum Error {
@@ -126,13 +123,12 @@ pub(crate) fn discovery_config_map_name(cluster_name: &ClusterName) -> String {
 
 /// Shared metadata for both the freshly built and the re-emitted discovery ConfigMap, so
 /// that the two are identical apart from their contents. The ConfigMap carries the standard
-/// recommended labels (required by `ClusterResources::add`), attributed to the namenode role
-/// and a `discovery` role group.
+/// recommended labels (required by `ClusterResources::add`), attributed to the namenode role.
 fn discovery_config_map_meta(cluster: &ValidatedCluster) -> ObjectMetaBuilder {
     object_meta(
         cluster,
         discovery_config_map_name(&cluster.name),
-        cluster.recommended_labels(&HdfsNodeRole::Name, &DISCOVERY_ROLE_GROUP),
+        recommended_labels_for_role_resources(cluster, &HdfsNodeRole::Name),
     )
 }
 

--- a/rust/operator-binary/src/controller/build/resource/pdb.rs
+++ b/rust/operator-binary/src/controller/build/resource/pdb.rs
@@ -2,11 +2,11 @@ use std::cmp::{max, min};
 
 use stackable_operator::{
     k8s_openapi::api::policy::v1::PodDisruptionBudget,
-    v2::{builder::pdb::pod_disruption_budget_builder_with_role, types::operator::RoleName},
+    v2::builder::pdb::pod_disruption_budget_builder_with_role,
 };
 
 use crate::{
-    controller::{ValidatedCluster, build, controller_name, operator_name, product_name},
+    controller::{CONTROLLER_NAME, OPERATOR_NAME, PRODUCT_NAME, ValidatedCluster, build},
     crd::HdfsNodeRole,
 };
 
@@ -25,13 +25,12 @@ pub fn build_pdb(cluster: &ValidatedCluster, role: &HdfsNodeRole) -> Option<PodD
         ),
         HdfsNodeRole::Journal => max_unavailable_journal_nodes(),
     });
-    let role_name: RoleName = role.into();
     let pdb = pod_disruption_budget_builder_with_role(
         cluster,
-        &product_name(),
-        &role_name,
-        &operator_name(),
-        &controller_name(),
+        &PRODUCT_NAME,
+        role,
+        &OPERATOR_NAME,
+        &CONTROLLER_NAME,
     )
     .with_max_unavailable(max_unavailable)
     .build();

--- a/rust/operator-binary/src/controller/build/resource/rbac.rs
+++ b/rust/operator-binary/src/controller/build/resource/rbac.rs
@@ -1,27 +1,18 @@
 //! Builds the RBAC resources (ServiceAccount + RoleBinding) shared by all role groups.
 
-use std::str::FromStr;
-
 use stackable_operator::{
     k8s_openapi::api::{core::v1::ServiceAccount, rbac::v1::RoleBinding},
-    kvp::Labels,
-    v2::{
-        rbac,
-        types::operator::{RoleGroupName, RoleName},
-    },
+    v2::rbac,
 };
 
-use crate::controller::ValidatedCluster;
-
-stackable_operator::constant!(NONE_ROLE_NAME: RoleName = "none");
-stackable_operator::constant!(NONE_ROLE_GROUP_NAME: RoleGroupName = "none");
+use crate::controller::{ValidatedCluster, build::recommended_labels_for_cluster_resources};
 
 /// Builds the [`ServiceAccount`] that the role-group Pods run under.
 pub fn build_service_account(cluster: &ValidatedCluster) -> ServiceAccount {
     rbac::build_service_account(
         cluster,
         &cluster.cluster_resource_names(),
-        rbac_labels(cluster),
+        recommended_labels_for_cluster_resources(cluster),
     )
 }
 
@@ -31,14 +22,8 @@ pub fn build_role_binding(cluster: &ValidatedCluster) -> RoleBinding {
     rbac::build_role_binding(
         cluster,
         &cluster.cluster_resource_names(),
-        rbac_labels(cluster),
+        recommended_labels_for_cluster_resources(cluster),
     )
-}
-
-/// Both resources are shared by the whole cluster rather than tied to a role or role group, so
-/// the recommended labels carry `none` for both values.
-fn rbac_labels(cluster: &ValidatedCluster) -> Labels {
-    cluster.recommended_labels_for(&NONE_ROLE_NAME, &NONE_ROLE_GROUP_NAME)
 }
 
 #[cfg(test)]
@@ -66,13 +51,10 @@ mod tests {
                 "apiVersion": "v1",
                 "kind": "ServiceAccount",
                 "metadata": {
-                    // The RBAC resources are cluster-shared, so role and role group are `none`.
                     "labels": {
-                        "app.kubernetes.io/component": "none",
                         "app.kubernetes.io/instance": "my-hdfs",
-                        "app.kubernetes.io/managed-by": "hdfs.stackable.tech_hdfs-operator-hdfs-controller",
+                        "app.kubernetes.io/managed-by": "hdfs.stackable.tech_hdfs-controller",
                         "app.kubernetes.io/name": "hdfs",
-                        "app.kubernetes.io/role-group": "none",
                         "app.kubernetes.io/version": app_version_label("3.4.0"),
                         "stackable.tech/vendor": "Stackable"
                     },
@@ -103,11 +85,9 @@ mod tests {
                 "kind": "RoleBinding",
                 "metadata": {
                     "labels": {
-                        "app.kubernetes.io/component": "none",
                         "app.kubernetes.io/instance": "my-hdfs",
-                        "app.kubernetes.io/managed-by": "hdfs.stackable.tech_hdfs-operator-hdfs-controller",
+                        "app.kubernetes.io/managed-by": "hdfs.stackable.tech_hdfs-controller",
                         "app.kubernetes.io/name": "hdfs",
-                        "app.kubernetes.io/role-group": "none",
                         "app.kubernetes.io/version": app_version_label("3.4.0"),
                         "stackable.tech/vendor": "Stackable"
                     },

--- a/rust/operator-binary/src/controller/build/resource/service.rs
+++ b/rust/operator-binary/src/controller/build/resource/service.rs
@@ -12,7 +12,10 @@ use stackable_operator::{
 };
 
 use crate::{
-    controller::{ValidatedCluster, build},
+    controller::{
+        ValidatedCluster,
+        build::{self, recommended_labels_for_role_group_resources},
+    },
     crd::HdfsNodeRole,
 };
 
@@ -34,7 +37,10 @@ pub(crate) fn rolegroup_headless_service(
     role: &HdfsNodeRole,
     role_group_name: &RoleGroupName,
 ) -> Result<Service> {
-    tracing::info!("Setting up headless Service for role {role} role group {role_group_name}");
+    tracing::info!(
+        "Setting up headless Service for role {role} role group {role_group_name}",
+        role = role.as_ref()
+    );
 
     let service_spec = ServiceSpec {
         // Internal communication does not need to be exposed
@@ -66,7 +72,7 @@ pub(crate) fn rolegroup_headless_service(
             cluster
                 .governing_service_name(role, role_group_name)
                 .to_string(),
-            cluster.recommended_labels(role, role_group_name),
+            recommended_labels_for_role_group_resources(cluster, role, role_group_name),
         )
         .build(),
         spec: Some(service_spec),
@@ -79,7 +85,10 @@ pub(crate) fn rolegroup_metrics_service(
     role: &HdfsNodeRole,
     role_group_name: &RoleGroupName,
 ) -> Result<Service> {
-    tracing::info!("Setting up metrics Service for role {role} role group {role_group_name}");
+    tracing::info!(
+        "Setting up metrics Service for role {role} role group {role_group_name}",
+        role = role.as_ref()
+    );
 
     let service_spec = ServiceSpec {
         // Internal communication does not need to be exposed
@@ -112,7 +121,7 @@ pub(crate) fn rolegroup_metrics_service(
                 .role_group_resource_names(role, role_group_name)
                 .metrics_service_name()
                 .to_string(),
-            cluster.recommended_labels(role, role_group_name),
+            recommended_labels_for_role_group_resources(cluster, role, role_group_name),
         )
         .with_labels(prometheus_labels(&Scraping::Enabled))
         .with_annotations(prometheus_annotations(
@@ -168,7 +177,7 @@ mod tests {
                     "labels": {
                         "app.kubernetes.io/component": "namenode",
                         "app.kubernetes.io/instance": "hdfs",
-                        "app.kubernetes.io/managed-by": "hdfs.stackable.tech_hdfs-operator-hdfs-controller",
+                        "app.kubernetes.io/managed-by": "hdfs.stackable.tech_hdfs-controller",
                         "app.kubernetes.io/name": "hdfs",
                         "app.kubernetes.io/role-group": "default",
                         "app.kubernetes.io/version": app_version_label("3.4.0"),

--- a/rust/operator-binary/src/controller/build/resource/statefulset.rs
+++ b/rust/operator-binary/src/controller/build/resource/statefulset.rs
@@ -48,7 +48,10 @@ pub(crate) fn build_rolegroup_statefulset(
     role_group_name: &RoleGroupName,
     rolegroup_config: &ValidatedRoleGroupConfig,
 ) -> Result<StatefulSet, Error> {
-    tracing::info!("Setting up StatefulSet for role {role} role group {role_group_name}");
+    tracing::info!(
+        "Setting up StatefulSet for role {role} role group {role_group_name}",
+        role = (**role).clone()
+    );
 
     let image = &validated.image;
     let merged_config = &rolegroup_config.config;

--- a/rust/operator-binary/src/controller/build/resource/statefulset.rs
+++ b/rust/operator-binary/src/controller/build/resource/statefulset.rs
@@ -50,7 +50,7 @@ pub(crate) fn build_rolegroup_statefulset(
 ) -> Result<StatefulSet, Error> {
     tracing::info!(
         "Setting up StatefulSet for role {role} role group {role_group_name}",
-        role = (**role).clone()
+        role = role.as_ref()
     );
 
     let image = &validated.image;

--- a/rust/operator-binary/src/controller/mod.rs
+++ b/rust/operator-binary/src/controller/mod.rs
@@ -2,6 +2,7 @@ use std::{collections::BTreeMap, marker::PhantomData, str::FromStr};
 
 use stackable_operator::{
     commons::product_image_selection::ResolvedProductImage,
+    constant,
     crd::listener,
     k8s_openapi::api::{
         apps::v1::StatefulSet,
@@ -10,30 +11,28 @@ use stackable_operator::{
         rbac::v1::RoleBinding,
     },
     kube::{Resource, api::ObjectMeta},
-    kvp::Labels,
     v2::{
         HasName, HasUid, NameIsValidLabelValue,
-        kvp::label::recommended_labels,
         role_group_utils::ResourceNames,
         role_utils::{self, RoleGroupConfig},
         types::{
             kubernetes::{ConfigMapName, NamespaceName, ServiceName, Uid},
             operator::{
                 ClusterName, ControllerName, OperatorName, ProductName, ProductVersion,
-                RoleGroupName, RoleName,
+                RoleGroupName,
             },
         },
     },
 };
 
 use crate::{
-    OPERATOR_NAME,
+    HDFS_OPERATOR_NAME,
     controller::build::opa::HdfsOpaConfig,
     crd::{
         AnyNodeConfig, HdfsNodeRole, UpgradeState, constants::APP_NAME,
         security::AuthenticationConfig, v1alpha1,
     },
-    hdfs_controller::RESOURCE_MANAGER_HDFS_CONTROLLER,
+    hdfs_controller::HDFS_CONTROLLER_NAME,
 };
 
 pub mod apply;
@@ -41,6 +40,10 @@ pub mod build;
 pub mod dereference;
 pub mod update_status;
 pub mod validate;
+
+constant!(PRODUCT_NAME: ProductName = APP_NAME);
+constant!(OPERATOR_NAME: OperatorName = HDFS_OPERATOR_NAME);
+constant!(CONTROLLER_NAME: ControllerName = HDFS_CONTROLLER_NAME);
 
 /// Marker for prepared Kubernetes resources which are not applied yet.
 pub struct Prepared;
@@ -176,7 +179,7 @@ impl ValidatedCluster {
     pub fn cluster_resource_names(&self) -> role_utils::ResourceNames {
         role_utils::ResourceNames {
             cluster_name: self.name.clone(),
-            product_name: product_name(),
+            product_name: PRODUCT_NAME.clone(),
         }
     }
 
@@ -188,44 +191,9 @@ impl ValidatedCluster {
     ) -> ResourceNames {
         ResourceNames {
             cluster_name: self.name.clone(),
-            role_name: role.into(),
+            role_name: (**role).clone(),
             role_group_name: role_group_name.clone(),
         }
-    }
-
-    /// Recommended labels for a resource that is not tied to a concrete [`HdfsNodeRole`], using a free-form role/role-group label value.
-    pub fn recommended_labels_for(
-        &self,
-        role_name: &RoleName,
-        role_group_name: &RoleGroupName,
-    ) -> Labels {
-        self.recommended_labels_with(&self.product_version, role_name, role_group_name)
-    }
-
-    fn recommended_labels_with(
-        &self,
-        product_version: &ProductVersion,
-        role_name: &RoleName,
-        role_group_name: &RoleGroupName,
-    ) -> Labels {
-        recommended_labels(
-            self,
-            &product_name(),
-            product_version,
-            &operator_name(),
-            &controller_name(),
-            role_name,
-            role_group_name,
-        )
-    }
-
-    /// Recommended labels for a role-group resource.
-    pub fn recommended_labels(
-        &self,
-        role: &HdfsNodeRole,
-        role_group_name: &RoleGroupName,
-    ) -> Labels {
-        self.recommended_labels_for(&role.into(), role_group_name)
     }
 
     /// The name of a role group's governing headless Service.
@@ -250,22 +218,6 @@ impl ValidatedCluster {
         )
         .expect("a qualified role group name is a valid Service name")
     }
-}
-
-/// The product name (`hdfs`) as a type-safe label value.
-pub(crate) fn product_name() -> ProductName {
-    ProductName::from_str(APP_NAME).expect("'hdfs' is a valid product name")
-}
-
-/// The operator name as a type-safe label value.
-pub(crate) fn operator_name() -> OperatorName {
-    OperatorName::from_str(OPERATOR_NAME).expect("the operator name is a valid label value")
-}
-
-/// The controller name as a type-safe label value.
-pub(crate) fn controller_name() -> ControllerName {
-    ControllerName::from_str(RESOURCE_MANAGER_HDFS_CONTROLLER)
-        .expect("the controller name is a valid label value")
 }
 
 /// Lets [`ValidatedCluster`] be used as the owner [`Resource`]. The kind/group/version/plural
@@ -384,22 +336,4 @@ impl ValidatedClusterConfig {
 #[derive(Clone, Debug)]
 pub struct ValidatedRoleConfig {
     pub pdb: stackable_operator::commons::pdb::PdbConfig,
-}
-
-#[cfg(test)]
-mod tests {
-    use stackable_operator::v2::types::operator::RoleName;
-    use strum::IntoEnumIterator;
-
-    use crate::crd::HdfsNodeRole;
-
-    /// Locks the invariant behind the `expect` in the `From<HdfsNodeRole> for RoleName` impls:
-    /// every `HdfsNodeRole` variant (present and future) must serialise to a valid `RoleName`.
-    #[test]
-    fn every_hdfs_node_role_serialises_to_a_valid_role_name() {
-        for role in HdfsNodeRole::iter() {
-            let _: RoleName = (&role).into();
-            let _: RoleName = role.into();
-        }
-    }
 }

--- a/rust/operator-binary/src/controller/update_status.rs
+++ b/rust/operator-binary/src/controller/update_status.rs
@@ -11,7 +11,7 @@ use stackable_operator::{
 use strum::{EnumDiscriminants, IntoStaticStr};
 
 use crate::{
-    OPERATOR_NAME,
+    HDFS_OPERATOR_NAME,
     controller::{ValidatedCluster, apply::AppliedResources},
     crd::{HdfsClusterStatus, UpgradeState, v1alpha1},
 };
@@ -78,7 +78,7 @@ pub async fn update_status(
     };
 
     client
-        .apply_patch_status(OPERATOR_NAME, hdfs, &status)
+        .apply_patch_status(HDFS_OPERATOR_NAME, hdfs, &status)
         .await
         .context(ApplyStatusSnafu)?;
 

--- a/rust/operator-binary/src/controller/validate.rs
+++ b/rust/operator-binary/src/controller/validate.rs
@@ -6,11 +6,10 @@ use snafu::{ResultExt, Snafu};
 use stackable_operator::{
     commons::product_image_selection,
     config::{fragment::FromFragment, merge::Merge},
-    role_utils::{GenericRoleConfig, Role},
+    role_utils::GenericRoleConfig,
     v2::{
-        builder::pod::container::{EnvVarName, EnvVarSet},
         controller_utils::{get_cluster_name, get_namespace, get_uid},
-        role_utils::{JavaCommonConfig, with_validated_config},
+        role_utils::{JavaCommonConfig, Role, with_validated_config},
         types::operator::RoleGroupName,
     },
 };
@@ -49,11 +48,6 @@ pub enum Error {
     #[snafu(display("failed to get the cluster uid"))]
     GetClusterUid {
         source: stackable_operator::v2::controller_utils::Error,
-    },
-
-    #[snafu(display("invalid environment variable override name"))]
-    ParseEnvVarName {
-        source: stackable_operator::v2::macros::attributed_string_type::Error,
     },
 
     #[snafu(display("invalid role group name {role_group:?}"))]
@@ -190,21 +184,13 @@ where
             >(role_group, role, &default_config)
             .context(ValidateRoleGroupConfigSnafu)?;
 
-            let mut env_overrides = EnvVarSet::new();
-            for (env_var_name, env_var_value) in validated.config.env_overrides {
-                env_overrides = env_overrides.with_value(
-                    &EnvVarName::from_str(&env_var_name).context(ParseEnvVarNameSnafu)?,
-                    env_var_value,
-                );
-            }
-
             // Re-wrap the per-role validated config into the role-agnostic
             // `AnyNodeConfig`; the merged overrides carry over unchanged.
             let validated = ValidatedRoleGroupConfig {
                 replicas: validated.replicas,
                 config: wrap(validated.config.config),
                 config_overrides: validated.config.config_overrides,
-                env_overrides,
+                env_overrides: validated.config.env_overrides.into(),
                 cli_overrides: validated.config.cli_overrides,
                 pod_overrides: validated.config.pod_overrides,
                 product_specific_common_config: validated.config.product_specific_common_config,

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -23,6 +23,7 @@ use stackable_operator::{
         fragment::{Fragment, ValidationError},
         merge::Merge,
     },
+    constant,
     crd::listener,
     deep_merger::ObjectOverrides,
     k8s_openapi::apimachinery::pkg::api::resource::Quantity,
@@ -31,14 +32,14 @@ use stackable_operator::{
         self,
         spec::{ContainerLogConfig, Logging},
     },
-    role_utils::{self, GenericRoleConfig, Role},
+    role_utils::{self, GenericRoleConfig},
     schemars::{self, JsonSchema},
     shared::time::Duration,
     status::condition::{ClusterCondition, HasStatusCondition},
     utils::cluster_info::KubernetesClusterInfo,
     v2::{
         config_overrides::KeyValueConfigOverrides,
-        role_utils::JavaCommonConfig,
+        role_utils::{JavaCommonConfig, Role},
         types::{
             common::Port,
             kubernetes::{ConfigMapName, ListenerClassName, NamespaceName, ServiceName},
@@ -455,12 +456,14 @@ impl AnyNodeConfig {
     }
 }
 
+constant!(JOURNALNODE_ROLE_NAME: RoleName = "journalnode");
+constant!(NAMENODE_ROLE_NAME: RoleName = "namenode");
+constant!(DATANODE_ROLE_NAME: RoleName = "datanode");
+
 #[derive(
     Clone,
     Copy,
     Debug,
-    Deserialize,
-    Display,
     EnumIter,
     EnumString,
     IntoStaticStr,
@@ -470,29 +473,25 @@ impl AnyNodeConfig {
     Ord,
     PartialEq,
     PartialOrd,
-    Serialize,
 )]
 pub enum HdfsNodeRole {
     #[serde(rename = "journalnode")]
-    #[strum(serialize = "journalnode")]
     Journal,
     #[serde(rename = "namenode")]
-    #[strum(serialize = "namenode")]
     Name,
     #[serde(rename = "datanode")]
-    #[strum(serialize = "datanode")]
     Data,
 }
 
-impl From<HdfsNodeRole> for RoleName {
-    fn from(value: HdfsNodeRole) -> Self {
-        RoleName::from_str(&value.to_string()).expect("a HdfsNodeRole is a valid role name")
-    }
-}
+impl Deref for HdfsNodeRole {
+    type Target = RoleName;
 
-impl From<&HdfsNodeRole> for RoleName {
-    fn from(value: &HdfsNodeRole) -> Self {
-        RoleName::from_str(&value.to_string()).expect("a HdfsNodeRole is a valid role name")
+    fn deref(&self) -> &Self::Target {
+        match self {
+            HdfsNodeRole::Journal => &JOURNALNODE_ROLE_NAME,
+            HdfsNodeRole::Name => &NAMENODE_ROLE_NAME,
+            HdfsNodeRole::Data => &DATANODE_ROLE_NAME,
+        }
     }
 }
 
@@ -564,7 +563,7 @@ pub(crate) fn is_namenode_listener(listener_name: &str, cluster_name: &str) -> b
     listener_name.starts_with(&format!(
         "{listener_volume}-{cluster_name}-{role}-",
         listener_volume = *LISTENER_VOLUME_NAME,
-        role = HdfsNodeRole::Name,
+        role = *HdfsNodeRole::Name,
     ))
 }
 

--- a/rust/operator-binary/src/hdfs_controller.rs
+++ b/rust/operator-binary/src/hdfs_controller.rs
@@ -26,7 +26,6 @@ use crate::{
     event::{build_invalid_replica_message, publish_warning_event},
 };
 
-pub const RESOURCE_MANAGER_HDFS_CONTROLLER: &str = "hdfs-operator-hdfs-controller";
 pub const HDFS_CONTROLLER_NAME: &str = "hdfs-controller";
 
 #[derive(Snafu, Debug, EnumDiscriminants)]

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -53,8 +53,9 @@ mod built_info {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
 }
 
-pub const OPERATOR_NAME: &str = "hdfs.stackable.tech";
-pub const HDFS_FULL_CONTROLLER_NAME: &str = concatcp!(HDFS_CONTROLLER_NAME, '.', OPERATOR_NAME);
+pub const HDFS_OPERATOR_NAME: &str = "hdfs.stackable.tech";
+pub const HDFS_FULL_CONTROLLER_NAME: &str =
+    concatcp!(HDFS_CONTROLLER_NAME, '.', HDFS_OPERATOR_NAME);
 
 #[derive(clap::Parser)]
 #[clap(about, author)]
@@ -101,9 +102,11 @@ async fn main() -> anyhow::Result<()> {
                     .run(sigterm_watcher.handle())
                     .map(anyhow::Ok);
 
-            let client =
-                client::initialize_operator(Some(OPERATOR_NAME.to_string()), &common.cluster_info)
-                    .await?;
+            let client = client::initialize_operator(
+                Some(HDFS_OPERATOR_NAME.to_string()),
+                &common.cluster_info,
+            )
+            .await?;
 
             let webhook_server = create_webhook_server(
                 &operator_environment,

--- a/tests/templates/kuttl/smoke/30-assert.yaml.j2
+++ b/tests/templates/kuttl/smoke/30-assert.yaml.j2
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/component: namenode
     app.kubernetes.io/instance: hdfs
-    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-operator-hdfs-controller
+    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-controller
     app.kubernetes.io/name: hdfs
     app.kubernetes.io/role-group: default
     stackable.tech/vendor: Stackable
@@ -47,7 +47,7 @@ metadata:
   labels:
     app.kubernetes.io/component: namenode
     app.kubernetes.io/instance: hdfs
-    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-operator-hdfs-controller
+    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-controller
     app.kubernetes.io/name: hdfs
     app.kubernetes.io/role-group: default
     prometheus.io/scrape: "true"
@@ -81,7 +81,7 @@ metadata:
   labels:
     app.kubernetes.io/component: datanode
     app.kubernetes.io/instance: hdfs
-    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-operator-hdfs-controller
+    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-controller
     app.kubernetes.io/name: hdfs
     app.kubernetes.io/role-group: default
     stackable.tech/vendor: Stackable
@@ -122,7 +122,7 @@ metadata:
   labels:
     app.kubernetes.io/component: datanode
     app.kubernetes.io/instance: hdfs
-    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-operator-hdfs-controller
+    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-controller
     app.kubernetes.io/name: hdfs
     app.kubernetes.io/role-group: default
     prometheus.io/scrape: "true"
@@ -156,7 +156,7 @@ metadata:
   labels:
     app.kubernetes.io/component: journalnode
     app.kubernetes.io/instance: hdfs
-    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-operator-hdfs-controller
+    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-controller
     app.kubernetes.io/name: hdfs
     app.kubernetes.io/role-group: default
     stackable.tech/vendor: Stackable
@@ -194,7 +194,7 @@ metadata:
   labels:
     app.kubernetes.io/component: journalnode
     app.kubernetes.io/instance: hdfs
-    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-operator-hdfs-controller
+    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-controller
     app.kubernetes.io/name: hdfs
     app.kubernetes.io/role-group: default
     prometheus.io/scrape: "true"
@@ -228,7 +228,7 @@ metadata:
   labels:
     app.kubernetes.io/component: namenode
     app.kubernetes.io/instance: hdfs
-    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-operator-hdfs-controller
+    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-controller
     app.kubernetes.io/name: hdfs
     app.kubernetes.io/role-group: default
     stackable.tech/vendor: Stackable
@@ -812,7 +812,7 @@ metadata:
   labels:
     app.kubernetes.io/component: datanode
     app.kubernetes.io/instance: hdfs
-    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-operator-hdfs-controller
+    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-controller
     app.kubernetes.io/name: hdfs
     app.kubernetes.io/role-group: default
     stackable.tech/vendor: Stackable
@@ -1206,7 +1206,7 @@ metadata:
   labels:
     app.kubernetes.io/component: journalnode
     app.kubernetes.io/instance: hdfs
-    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-operator-hdfs-controller
+    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-controller
     app.kubernetes.io/name: hdfs
     app.kubernetes.io/role-group: default
     stackable.tech/vendor: Stackable
@@ -1424,7 +1424,7 @@ metadata:
   labels:
     app.kubernetes.io/component: namenode
     app.kubernetes.io/instance: hdfs
-    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-operator-hdfs-controller
+    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-controller
     app.kubernetes.io/name: hdfs
     app.kubernetes.io/role-group: default
     stackable.tech/vendor: Stackable
@@ -1441,7 +1441,7 @@ metadata:
   labels:
     app.kubernetes.io/component: datanode
     app.kubernetes.io/instance: hdfs
-    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-operator-hdfs-controller
+    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-controller
     app.kubernetes.io/name: hdfs
     app.kubernetes.io/role-group: default
     stackable.tech/vendor: Stackable
@@ -1458,7 +1458,7 @@ metadata:
   labels:
     app.kubernetes.io/component: journalnode
     app.kubernetes.io/instance: hdfs
-    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-operator-hdfs-controller
+    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-controller
     app.kubernetes.io/name: hdfs
     app.kubernetes.io/role-group: default
     stackable.tech/vendor: Stackable
@@ -1474,7 +1474,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: hdfs
-    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-operator-hdfs-controller
+    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-controller
     app.kubernetes.io/name: hdfs
   name: hdfs-serviceaccount
   ownerReferences:
@@ -1488,7 +1488,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: hdfs
-    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-operator-hdfs-controller
+    app.kubernetes.io/managed-by: hdfs.stackable.tech_hdfs-controller
     app.kubernetes.io/name: hdfs
   name: hdfs-rolebinding
   ownerReferences:


### PR DESCRIPTION
## Description

Upgrade to stackable-operator 0.116.0 and apply the changes described in stackabletech/issues#877.

Part of stackabletech/issues#877

```
--- PASS: kuttl (637.39s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_hadoop-3.5.0_zookeeper-3.9.5_zookeeper-latest-3.9.5_number-of-datanodes-2_datanode-pvcs-2hdd-1ssd_listener-class-cluster-internal_openshift-false (637.38s)
PASS
```


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [x] ~Release note snippet added~ HDFS is (unlike most of the other operators) non-breaking with this PR: its immutable fields (selector + PVC templates) never contained the placeholder labels in the first place, and this PR leaves those fields unchanged.

### Reviewer

- [x] Code contains useful comments
- [ ] Code contains useful logging statements
- [x] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
